### PR TITLE
Explicit provider bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,11 @@ concierge prepare -p dev
 | Preset Name | Included                                                         |
 | :---------: | :--------------------------------------------------------------- |
 |    `dev`    | `juju`, `microk8s`, `lxd` `snapcraft`, `charmcraft`, `rockcraft` |
-|    `k8s`    | `juju`, `microk8s`, `rockcraft`, `charmcraft`                    |
+|    `k8s`    | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`             |
 |  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                         |
+
+Note that in the `k8s` preset, while `lxd` is installed, it is not bootstrapped. It is installed
+and initialised with enough config such that `charmcraft` can use it as a build backend.
 
 ### Config File
 
@@ -140,6 +143,8 @@ providers:
   microk8s:
     # (Optional) Enable or disable MicroK8s.
     enable: true | false
+    # (Optional) Whether or not to bootstrap a controller onto MicroK8s.
+    bootstrap: true | false
     # (Optional): Channel from which to install MicroK8s.
     channel: <channel>
     # (Optional): MicroK8s addons to enable.
@@ -150,6 +155,8 @@ providers:
   lxd:
     # (Optional) Enable or disable LXD.
     enable: true | false
+    # (Optional) Whether or not to bootstrap a controller onto LXD.
+    bootstrap: true | false
     # (Optional): Channel from which to install LXD.
     channel: <channel>
 

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -28,15 +28,17 @@ type providerConfig struct {
 
 // lxdConfig represents how LXD should be configured on the host.
 type lxdConfig struct {
-	Enable  bool   `mapstructure:"enable"`
-	Channel string `mapstructure:"channel"`
+	Enable    bool   `mapstructure:"enable"`
+	Bootstrap bool   `mapstructure:"bootstrap"`
+	Channel   string `mapstructure:"channel"`
 }
 
 // microk8sConfig represents how MicroK8s should be configured on the host.
 type microk8sConfig struct {
-	Enable  bool     `mapstructure:"enable"`
-	Channel string   `mapstructure:"channel"`
-	Addons  []string `mapstructure:"addons"`
+	Enable    bool     `mapstructure:"enable"`
+	Bootstrap bool     `mapstructure:"bootstrap"`
+	Channel   string   `mapstructure:"channel"`
+	Addons    []string `mapstructure:"addons"`
 }
 
 // hostConfig is a top-level field containing addition configuration for the host being

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -39,12 +39,14 @@ var defaultSnaps []string = []string{
 
 // defaultLXDConfig is the standard LXD config used throughout presets.
 var defaultLXDConfig lxdConfig = lxdConfig{
-	Enable: true,
+	Enable:    true,
+	Bootstrap: true,
 }
 
 // defaultK8sConfig is the standard MicroK8s config used throughout presets.
 var defaultK8sConfig microk8sConfig = microk8sConfig{
-	Enable: true,
+	Enable:    true,
+	Bootstrap: true,
 	Addons: []string{
 		"hostpath-storage",
 		"dns",
@@ -71,6 +73,8 @@ var machinePreset *Config = &Config{
 var k8sPreset *Config = &Config{
 	Juju: defaultJujuConfig,
 	Providers: providerConfig{
+		// Enable LXD so charms can be built, but don't bootstrap onto it.
+		LXD:      lxdConfig{Enable: true},
 		MicroK8s: defaultK8sConfig,
 	},
 	Host: hostConfig{

--- a/internal/handlers/juju.go
+++ b/internal/handlers/juju.go
@@ -90,6 +90,10 @@ func (j *JujuHandler) bootstrap() error {
 
 // bootstrapProvider bootstraps one specific provider.
 func (j *JujuHandler) bootstrapProvider(provider providers.Provider) error {
+	if !provider.Bootstrap() {
+		return nil
+	}
+
 	controllerName := fmt.Sprintf("concierge-%s", provider.Name())
 
 	bootstrapped, err := j.checkBootstrapped(controllerName)

--- a/internal/providers/lxd.go
+++ b/internal/providers/lxd.go
@@ -19,14 +19,19 @@ func NewLXD(runner *runner.Runner, config *config.Config) *LXD {
 		channel = config.Providers.LXD.Channel
 	}
 
-	return &LXD{Channel: channel, runner: runner}
+	return &LXD{
+		Channel:   channel,
+		runner:    runner,
+		bootstrap: config.Providers.LXD.Bootstrap,
+	}
 }
 
 // LXD represents a LXD install on a given machine.
 type LXD struct {
 	Channel string
 
-	runner *runner.Runner
+	bootstrap bool
+	runner    *runner.Runner
 }
 
 // Prepare installs and configures LXD such that it can work in testing environments.
@@ -60,6 +65,9 @@ func (l *LXD) Prepare() error {
 
 // Name reports the name of the provider for Concierge's purposes.
 func (l *LXD) Name() string { return "lxd" }
+
+// Bootstrap reports whether a Juju controller should be bootstrapped on LXD.
+func (l *LXD) Bootstrap() bool { return l.bootstrap }
 
 // CloudName reports the name of the provider as Juju sees it.
 func (l *LXD) CloudName() string { return "localhost" }

--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -33,9 +33,10 @@ func NewMicroK8s(runner *runner.Runner, config *config.Config) *MicroK8s {
 	}
 
 	return &MicroK8s{
-		Channel: channel,
-		Addons:  config.Providers.MicroK8s.Addons,
-		runner:  runner,
+		Channel:   channel,
+		Addons:    config.Providers.MicroK8s.Addons,
+		bootstrap: config.Providers.MicroK8s.Bootstrap,
+		runner:    runner,
 	}
 }
 
@@ -44,7 +45,8 @@ type MicroK8s struct {
 	Channel string
 	Addons  []string
 
-	runner *runner.Runner
+	bootstrap bool
+	runner    *runner.Runner
 }
 
 // Prepare installs and configures MicroK8s such that it can work in testing environments.
@@ -78,6 +80,9 @@ func (m *MicroK8s) Prepare() error {
 
 // Name reports the name of the provider for Concierge's purposes.
 func (m *MicroK8s) Name() string { return "microk8s" }
+
+// Bootstrap reports whether a Juju controller should be bootstrapped onto the provider.
+func (m *MicroK8s) Bootstrap() bool { return m.bootstrap }
 
 // CloudName reports the name of the provider as Juju sees it.
 func (m *MicroK8s) CloudName() string { return "microk8s" }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -13,6 +13,8 @@ type Provider interface {
 	Restore() error
 	// Name reports the name of the provider used internally by concierge.
 	Name() string
+	// Bootstrap reports whether or not a Juju controller should be bootstrapped on the provider.
+	Bootstrap() bool
 	// CloudName reports name of the provider as Juju sees it.
 	CloudName() string
 	// GroupName reports the name of a POSIX user group that can be used

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -30,14 +31,19 @@ func (r *Runner) Run(c *Command) (*CommandResult, error) {
 		logger = slog.With("group", c.Group)
 	}
 
-	cmd := exec.Command(os.Getenv("SHELL"), "-c", c.commandString())
+	shell, err := getShellPath()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine shell path to run command")
+	}
+
+	cmd := exec.Command(shell, "-c", c.commandString())
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
 	logger.Debug("Running command", "command", c.commandString())
-	err := cmd.Run()
+	err = cmd.Run()
 
 	if r.trace {
 		fmt.Print(generateTraceMessage(c.commandString(), stdout.String(), stderr.String()))
@@ -72,4 +78,31 @@ func generateTraceMessage(cmd, stdout, stderr string) string {
 		result = fmt.Sprintf("%s%s\n%s", result, green.Sprintf("Stderr:"), stderr)
 	}
 	return result
+}
+
+// getShellPath tries to find the path to the user's preferred shell, as per the `SHELL“
+// environment variable. If that cannot be found, it looks for a path to "bash", and to
+// "sh" in that order. If no shell can be found, then an error is returned.
+func getShellPath() (string, error) {
+	// If the `SHELL` var is set, return that.
+	shellVar := os.Getenv("SHELL")
+	if len(shellVar) > 0 {
+		return shellVar, nil
+	}
+
+	// Try both the command name (to lookup in PATH), and common default paths.
+	for _, shell := range []string{"bash", "/bin/bash", "sh", "/bin/sh"} {
+		// Check if the shell path exists
+		if _, err := os.Stat(shell); errors.Is(err, os.ErrNotExist) {
+			// If the path doesn't exist, the lookup the value in the `PATH` variable
+			path, err := exec.LookPath(shell)
+			if err != nil {
+				continue
+			}
+			return path, nil
+		}
+		return shell, nil
+	}
+
+	return "", fmt.Errorf("could not find path to a shell")
 }

--- a/tests/juju-model-defaults/concierge.yaml
+++ b/tests/juju-model-defaults/concierge.yaml
@@ -7,6 +7,7 @@ juju:
 providers:
   microk8s:
     enable: true
+    bootstrap: true
     channel: 1.31-strict/stable
     addons:
       - hostpath-storage

--- a/tests/preset-k8s-pack-charm/task.yaml
+++ b/tests/preset-k8s-pack-charm/task.yaml
@@ -1,0 +1,18 @@
+summary: Run concierge with the k8s preset, try to pack a charm
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${PROJECT_PATH}/tests/preset-k8s-pack-charm"
+
+  "$PROJECT_PATH"/concierge --trace prepare -p k8s
+
+  mkdir test-charm
+  pushd test-charm
+  charmcraft init --author concierge
+  charmcraft pack --verbose
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$PROJECT_PATH"/concierge --trace restore
+  fi

--- a/tests/preset-k8s/task.yaml
+++ b/tests/preset-k8s/task.yaml
@@ -29,6 +29,9 @@ execute: |
   juju model-defaults | grep test-mode | tr -s " " | MATCH "test-mode false true"
   juju model-defaults | grep automatically-retry-hooks | tr -s " " | MATCH "automatically-retry-hooks true false"
 
+  # Check that even though we installed/initialised LXD, we didn't bootstrap it
+  juju controllers | NOMATCH lxd-concierge
+
 restore: |
   if [[ -z "${CI:-}" ]]; then
     "$PROJECT_PATH"/concierge --trace restore

--- a/tests/provider-lxd/concierge.yaml
+++ b/tests/provider-lxd/concierge.yaml
@@ -1,4 +1,5 @@
 providers:
   lxd:
     enable: true
+    bootstrap: true
     channel: latest/stable

--- a/tests/provider-microk8s/concierge.yaml
+++ b/tests/provider-microk8s/concierge.yaml
@@ -1,6 +1,7 @@
 providers:
   microk8s:
     enable: true
+    bootstrap: true
     channel: 1.31-strict/stable
     addons:
       - hostpath-storage


### PR DESCRIPTION
This PR implements a new `bootstrap` option for providers.

This is because in some cases, it's desirable to have a provider
installed, but not bootstrapped with a Juju controller.

The most clear example of this is when building a K8s charm, LXD
is still required to build the charm with charmcraft.