### PR TITLE
feat!: require `concierge` to be run as `root`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Or you can clone, build and run like so:
 git clone https://github.com/jnsgruk/concierge
 cd concierge
 go build -o concierge main.go
-./concierge -h
+sudo ./concierge -h
 ```
 
 ## Usage
@@ -95,14 +95,14 @@ The best source of examples for how to invoke `concierge` can be found in the
 1. Run `concierge` using the `dev` preset, adding one additional snap, using CLI flags:
 
 ```bash
-concierge prepare -p dev --extra-snaps node/22/stable
+sudo concierge prepare -p dev --extra-snaps node/22/stable
 ```
 
 2. Run `concierge` using the `dev` preset, overriding the Juju channel:
 
 ```bash
 export CONCIERGE_JUJU_CHANNEL=3.6/beta
-concierge prepare -p dev
+sudo concierge prepare -p dev
 ```
 
 ## Configuration

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,7 @@ func parseLoggingFlags(flags *pflag.FlagSet) {
 
 	// Set the default log level to "DEBUG" if verbose is specified.
 	level := slog.LevelInfo
-	if !verbose && trace {
+	if verbose || trace {
 		level = slog.LevelDebug
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"log/slog"
 	"os"
+	"os/user"
 
 	"github.com/spf13/pflag"
 )
@@ -40,4 +42,17 @@ func parseLoggingFlags(flags *pflag.FlagSet) {
 	logger := slog.New(h)
 	slog.SetDefault(logger)
 	logLevel.Set(level)
+}
+
+func checkUser() error {
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	if user.Uid != "0" {
+		return fmt.Errorf("this command should be run with `sudo`, or as `root`")
+	}
+
+	return nil
 }

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -29,8 +29,9 @@ More information at https://github.com/jnsgruk/concierge.
 `,
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			parseLoggingFlags(cmd.Flags())
+			return checkUser()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -16,8 +16,9 @@ func restoreCmd() *cobra.Command {
 		Long:          "Restore the machine to it's pre-provisioned state.",
 		SilenceErrors: true,
 		SilenceUsage:  true,
-		PreRun: func(cmd *cobra.Command, args []string) {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			parseLoggingFlags(cmd.Flags())
+			return checkUser()
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			flags := cmd.Flags()

--- a/internal/handlers/deb.go
+++ b/internal/handlers/deb.go
@@ -86,6 +86,7 @@ func (h *DebHandler) removeDeb(d *packages.Deb) error {
 		return fmt.Errorf("failed to remove apt package '%s': %w", d.Name, err)
 	}
 
+	slog.Info("Removed apt package", "package", d.Name)
 	return nil
 }
 

--- a/internal/handlers/deb.go
+++ b/internal/handlers/deb.go
@@ -54,7 +54,7 @@ func (h *DebHandler) Restore() error {
 		}
 	}
 
-	cmd := runner.NewCommandSudo("apt-get", []string{"autoremove", "-y"})
+	cmd := runner.NewCommand("apt-get", []string{"autoremove", "-y"})
 
 	_, err := h.runner.Run(cmd)
 	if err != nil {
@@ -66,7 +66,7 @@ func (h *DebHandler) Restore() error {
 
 // installDeb uses `apt` to install the package on the system from the archives.
 func (h *DebHandler) installDeb(d *packages.Deb) error {
-	cmd := runner.NewCommandSudo("apt-get", []string{"install", "-y", d.Name})
+	cmd := runner.NewCommand("apt-get", []string{"install", "-y", d.Name})
 
 	_, err := h.runner.Run(cmd)
 	if err != nil {
@@ -79,7 +79,7 @@ func (h *DebHandler) installDeb(d *packages.Deb) error {
 
 // Remove uninstalls the deb from the system with `apt`.
 func (h *DebHandler) removeDeb(d *packages.Deb) error {
-	cmd := runner.NewCommandSudo("apt-get", []string{"remove", "-y", d.Name})
+	cmd := runner.NewCommand("apt-get", []string{"remove", "-y", d.Name})
 
 	_, err := h.runner.Run(cmd)
 	if err != nil {
@@ -91,7 +91,7 @@ func (h *DebHandler) removeDeb(d *packages.Deb) error {
 
 // updateAptCache is a helper method to update the host's package cache.
 func (h *DebHandler) updateAptCache() error {
-	cmd := runner.NewCommandSudo("apt-get", []string{"update"})
+	cmd := runner.NewCommand("apt-get", []string{"update"})
 
 	_, err := h.runner.Run(cmd)
 	if err != nil {

--- a/internal/handlers/snap.go
+++ b/internal/handlers/snap.go
@@ -72,7 +72,7 @@ func (h *SnapHandler) installSnap(s *packages.Snap) error {
 		args = append(args, "--classic")
 	}
 
-	cmd := runner.NewCommandSudo("snap", args)
+	cmd := runner.NewCommand("snap", args)
 	_, err = h.runner.Run(cmd)
 	if err != nil {
 		return fmt.Errorf("command failed: %w", err)
@@ -91,7 +91,7 @@ func (h *SnapHandler) installSnap(s *packages.Snap) error {
 func (h *SnapHandler) removeSnap(s *packages.Snap) error {
 	args := []string{"remove", s.Name, "--purge"}
 
-	cmd := runner.NewCommandSudo("snap", args)
+	cmd := runner.NewCommand("snap", args)
 	_, err := h.runner.Run(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to remove snap '%s': %w", s.Name, err)

--- a/internal/handlers/snap.go
+++ b/internal/handlers/snap.go
@@ -97,5 +97,6 @@ func (h *SnapHandler) removeSnap(s *packages.Snap) error {
 		return fmt.Errorf("failed to remove snap '%s': %w", s.Name, err)
 	}
 
+	slog.Info("Removed snap", "snap", s.Name)
 	return nil
 }

--- a/internal/packages/snap_test.go
+++ b/internal/packages/snap_test.go
@@ -1,7 +1,6 @@
 package packages
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -19,8 +18,11 @@ func TestNewSnapFromString(t *testing.T) {
 
 	for _, tc := range tests {
 		snap := NewSnapFromString(tc.input)
-		if !reflect.DeepEqual(tc.expected, snap) {
-			t.Fatalf("expected: %v, got: %v", tc.expected, snap)
+		if tc.expected.Channel != snap.Channel {
+			t.Fatalf("incorrect snap channel; expected: %v, got: %v", tc.expected, snap)
+		}
+		if tc.expected.Name != snap.Name {
+			t.Fatalf("incorrect snap name; expected: %v, got: %v", tc.expected, snap)
 		}
 	}
 }

--- a/internal/runner/user.go
+++ b/internal/runner/user.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+)
+
+// RealUser returns a user struct containing details of the "real" user, which
+// may differ from the current user when concierge is executed with `sudo`.
+func RealUser() (*user.User, error) {
+	realUser := os.Getenv("SUDO_USER")
+	if len(realUser) == 0 {
+		return user.Lookup("root")
+	}
+
+	return user.Lookup(realUser)
+}
+
+// ChownRecursively recursively changes ownership of a given filepath to the uid/gid of
+// the specified user.
+func ChownRecursively(path string, user *user.User) error {
+	uid, err := strconv.Atoi(user.Uid)
+	if err != nil {
+		return fmt.Errorf("failed to convert user id string to int: %w", err)
+	}
+	gid, err := strconv.Atoi(user.Gid)
+	if err != nil {
+		return fmt.Errorf("failed to convert group id string to int: %w", err)
+	}
+
+	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		err = os.Chown(path, uid, gid)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	slog.Debug("Filesystem ownership changed", "user", user.Username, "group", user.Gid, "path", path)
+	return err
+}


### PR DESCRIPTION
Before this commit, nearly all commands were run using `sudo`.
This was making the assumption that the user executing the
command was able to escalate using `sudo` with no password.
There was no handling in `concierge` to enable a password prompt,
so if the relevant configuration was not in place for NOPASSWD
sudo, then `concierge` would hang.

Additionally, by not being able to gurantee root privileges,
`concierge` was unable to take full advantage of the native
`snapd` client package for installing multiple snaps.