### PR TITLE
wip: add a google provider

### DIFF
--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -68,6 +68,8 @@ More information at https://github.com/jnsgruk/concierge.
 	flags.String("snapcraft-channel", "", "override snap channel for snapcraft")
 	flags.String("rockcraft-channel", "", "override snap channel for rockcraft")
 
+	flags.String("google-credential-file", "", "override path to google credentials file")
+
 	// Additional package specification
 	flags.StringSlice(
 		"extra-snaps",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -111,8 +111,11 @@ func getOverrides(flags *pflag.FlagSet) ConfigOverrides {
 		CharmcraftChannel: envOrFlagString(flags, "charmcraft-channel"),
 		SnapcraftChannel:  envOrFlagString(flags, "snapcraft-channel"),
 		RockcraftChannel:  envOrFlagString(flags, "rockcraft-channel"),
-		ExtraSnaps:        envOrFlagSlice(flags, "extra-snaps"),
-		ExtraDebs:         envOrFlagSlice(flags, "extra-debs"),
+
+		GoogleCredentialFile: envOrFlagString(flags, "google-credential-file"),
+
+		ExtraSnaps: envOrFlagSlice(flags, "extra-snaps"),
+		ExtraDebs:  envOrFlagSlice(flags, "extra-debs"),
 	}
 }
 

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -23,6 +23,7 @@ type jujuConfig struct {
 // providerConfig represents the set of providers to be configured and bootstrapped.
 type providerConfig struct {
 	LXD      lxdConfig      `mapstructure:"lxd"`
+	Google   googleConfig   `mapstructure:"google"`
 	MicroK8s microk8sConfig `mapstructure:"microk8s"`
 }
 
@@ -31,6 +32,13 @@ type lxdConfig struct {
 	Enable    bool   `mapstructure:"enable"`
 	Bootstrap bool   `mapstructure:"bootstrap"`
 	Channel   string `mapstructure:"channel"`
+}
+
+// googleConfig represents how Juju should be configured for Google Cloud use.
+type googleConfig struct {
+	Enable          bool   `mapstructure:"enable"`
+	Bootstrap       bool   `mapstructure:"bootstrap"`
+	CredentialsFile string `mapstructure:"credentials-file"`
 }
 
 // microk8sConfig represents how MicroK8s should be configured on the host.

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -8,6 +8,8 @@ type ConfigOverrides struct {
 	SnapcraftChannel  string
 	RockcraftChannel  string
 
+	GoogleCredentialFile string
+
 	ExtraSnaps []string
 	ExtraDebs  []string
 }

--- a/internal/juju/juju_test.go
+++ b/internal/juju/juju_test.go
@@ -1,4 +1,4 @@
-package handlers
+package juju
 
 import (
 	"fmt"
@@ -7,11 +7,13 @@ import (
 	"testing"
 
 	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/packages"
 	"github.com/jnsgruk/concierge/internal/providers"
 	"github.com/jnsgruk/concierge/internal/runnertest"
 )
 
 func setupHandler(preset string) (*runnertest.MockRunner, *JujuHandler, error) {
+func setupHandlerWithPreset(preset string) (*runnertest.MockRunner, *JujuHandler, error) {
 	var err error
 	var cfg *config.Config
 	var provider providers.Provider
@@ -32,10 +34,12 @@ func setupHandler(preset string) (*runnertest.MockRunner, *JujuHandler, error) {
 		provider = providers.NewMicroK8s(runner, cfg)
 	}
 
-	return runner, NewJujuHandler(cfg, runner, []providers.Provider{provider}), nil
+	handler := NewJujuHandler(cfg, runner, []providers.Provider{provider})
+	handler.snaps = []packages.SnapPackage{runnertest.NewTestSnap("juju", "", false, false)}
+	return runner, handler, nil
 }
 
-func TestJujuHandlerCommandsMicroK8s(t *testing.T) {
+func TestJujuHandlerCommandsPresets(t *testing.T) {
 	// Prevent the path of the test machine interfering with the test results.
 	path := os.Getenv("PATH")
 	os.Setenv("PATH", "")
@@ -51,6 +55,7 @@ func TestJujuHandlerCommandsMicroK8s(t *testing.T) {
 		{
 			preset: "machine",
 			expectedCommands: []string{
+				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-lxd",
 				"sudo -u test-user -g lxd juju bootstrap localhost concierge-lxd --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true",
 				"sudo -u test-user juju add-model -c concierge-lxd testing",
@@ -60,6 +65,7 @@ func TestJujuHandlerCommandsMicroK8s(t *testing.T) {
 		{
 			preset: "k8s",
 			expectedCommands: []string{
+				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-microk8s",
 				"sudo -u test-user -g snap_microk8s juju bootstrap microk8s concierge-microk8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true",
 				"sudo -u test-user juju add-model -c concierge-microk8s testing",
@@ -69,7 +75,7 @@ func TestJujuHandlerCommandsMicroK8s(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		runner, handler, err := setupHandler(tc.preset)
+		runner, handler, err := setupHandlerWithPreset(tc.preset)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
@@ -85,17 +91,19 @@ func TestJujuHandlerCommandsMicroK8s(t *testing.T) {
 		if !reflect.DeepEqual(tc.expectedDirs, runner.CreatedDirectories) {
 			t.Fatalf("expected: %v, got: %v", tc.expectedDirs, runner.CreatedDirectories)
 		}
+		if len(runner.CreatedFiles) > 0 {
+			t.Fatalf("expected no files to be created, got: %v", runner.CreatedFiles)
+		}
 	}
-
 }
 
-func TestJujuRestore(t *testing.T) {
+func TestJujuRestoreNoKillController(t *testing.T) {
 	// Prevent the path of the test machine interfering with the test results.
 	path := os.Getenv("PATH")
 	os.Setenv("PATH", "")
 	defer os.Setenv("PATH", path)
 
-	runner, handler, err := setupHandler("machine")
+	runner, handler, err := setupHandlerWithPreset("machine")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -103,8 +111,13 @@ func TestJujuRestore(t *testing.T) {
 	handler.Restore()
 
 	expectedDeleted := []string{".local/share/juju"}
+	expectedCommands := []string{"snap remove juju --purge"}
 
 	if !reflect.DeepEqual(expectedDeleted, runner.Deleted) {
 		t.Fatalf("expected: %v, got: %v", expectedDeleted, runner.Deleted)
+	}
+
+	if !reflect.DeepEqual(expectedCommands, runner.ExecutedCommands) {
+		t.Fatalf("expected: %v, got: %v", expectedCommands, runner.ExecutedCommands)
 	}
 }

--- a/internal/packages/deb_handler.go
+++ b/internal/packages/deb_handler.go
@@ -1,15 +1,14 @@
-package handlers
+package packages
 
 import (
 	"fmt"
 	"log/slog"
 
-	"github.com/jnsgruk/concierge/internal/packages"
 	"github.com/jnsgruk/concierge/internal/runner"
 )
 
 // NewDebHandler constructs a new instance of a DebHandler.
-func NewDebHandler(runner runner.CommandRunner, debs []*packages.Deb) *DebHandler {
+func NewDebHandler(runner runner.CommandRunner, debs []*Deb) *DebHandler {
 	return &DebHandler{
 		Debs:   debs,
 		runner: runner,
@@ -18,7 +17,7 @@ func NewDebHandler(runner runner.CommandRunner, debs []*packages.Deb) *DebHandle
 
 // DebHandler can install or remove a set of debs.
 type DebHandler struct {
-	Debs   []*packages.Deb
+	Debs   []*Deb
 	runner runner.CommandRunner
 }
 
@@ -53,7 +52,7 @@ func (h *DebHandler) Restore() error {
 
 	cmd := runner.NewCommand("apt-get", []string{"autoremove", "-y"})
 
-	_, err := h.runner.Run(cmd)
+	_, err := h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to install apt package: %w", err)
 	}
@@ -62,10 +61,10 @@ func (h *DebHandler) Restore() error {
 }
 
 // installDeb uses `apt` to install the package on the system from the archives.
-func (h *DebHandler) installDeb(d *packages.Deb) error {
+func (h *DebHandler) installDeb(d *Deb) error {
 	cmd := runner.NewCommand("apt-get", []string{"install", "-y", d.Name})
 
-	_, err := h.runner.Run(cmd)
+	_, err := h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to install apt package '%s': %w", d.Name, err)
 	}
@@ -75,10 +74,10 @@ func (h *DebHandler) installDeb(d *packages.Deb) error {
 }
 
 // Remove uninstalls the deb from the system with `apt`.
-func (h *DebHandler) removeDeb(d *packages.Deb) error {
+func (h *DebHandler) removeDeb(d *Deb) error {
 	cmd := runner.NewCommand("apt-get", []string{"remove", "-y", d.Name})
 
-	_, err := h.runner.Run(cmd)
+	_, err := h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to remove apt package '%s': %w", d.Name, err)
 	}
@@ -91,7 +90,7 @@ func (h *DebHandler) removeDeb(d *packages.Deb) error {
 func (h *DebHandler) updateAptCache() error {
 	cmd := runner.NewCommand("apt-get", []string{"update"})
 
-	_, err := h.runner.Run(cmd)
+	_, err := h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to update apt package lists: %w", err)
 	}

--- a/internal/packages/deb_handler_test.go
+++ b/internal/packages/deb_handler_test.go
@@ -1,11 +1,10 @@
-package handlers
+package packages
 
 import (
 	"os"
 	"reflect"
 	"testing"
 
-	"github.com/jnsgruk/concierge/internal/packages"
 	"github.com/jnsgruk/concierge/internal/runnertest"
 )
 
@@ -39,9 +38,9 @@ func TestDebHandlerCommands(t *testing.T) {
 		},
 	}
 
-	debs := []*packages.Deb{
-		packages.NewDeb("cowsay"),
-		packages.NewDeb("python3-venv"),
+	debs := []*Deb{
+		NewDeb("cowsay"),
+		NewDeb("python3-venv"),
 	}
 
 	for _, tc := range tests {

--- a/internal/packages/snap_handler.go
+++ b/internal/packages/snap_handler.go
@@ -1,15 +1,14 @@
-package handlers
+package packages
 
 import (
 	"fmt"
 	"log/slog"
 
-	"github.com/jnsgruk/concierge/internal/packages"
 	"github.com/jnsgruk/concierge/internal/runner"
 )
 
 // NewSnapHandler constructs a new instance of a SnapHandler.
-func NewSnapHandler(runner runner.CommandRunner, snaps []packages.SnapPackage) *SnapHandler {
+func NewSnapHandler(runner runner.CommandRunner, snaps []SnapPackage) *SnapHandler {
 	return &SnapHandler{
 		Snaps:  snaps,
 		runner: runner,
@@ -18,7 +17,7 @@ func NewSnapHandler(runner runner.CommandRunner, snaps []packages.SnapPackage) *
 
 // SnapHandler can install or remove a set of snaps.
 type SnapHandler struct {
-	Snaps  []packages.SnapPackage
+	Snaps  []SnapPackage
 	runner runner.CommandRunner
 }
 
@@ -46,7 +45,7 @@ func (h *SnapHandler) Restore() error {
 
 // installSnap ensures that the specified snap is installed at the specified channel.
 // If already installed, but on the wrong channel, the snap is refreshed.
-func (h *SnapHandler) installSnap(s packages.SnapPackage) error {
+func (h *SnapHandler) installSnap(s SnapPackage) error {
 	var action, logAction string
 	if s.Installed() {
 		action = "refresh"
@@ -72,7 +71,7 @@ func (h *SnapHandler) installSnap(s packages.SnapPackage) error {
 	}
 
 	cmd := runner.NewCommand("snap", args)
-	_, err = h.runner.Run(cmd)
+	_, err = h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("command failed: %w", err)
 	}
@@ -87,11 +86,11 @@ func (h *SnapHandler) installSnap(s packages.SnapPackage) error {
 }
 
 // Remove uninstalls the specified snap from the system, optionally purging its data.
-func (h *SnapHandler) removeSnap(s packages.SnapPackage) error {
+func (h *SnapHandler) removeSnap(s SnapPackage) error {
 	args := []string{"remove", s.Name(), "--purge"}
 
 	cmd := runner.NewCommand("snap", args)
-	_, err := h.runner.Run(cmd)
+	_, err := h.runner.RunExclusive(cmd)
 	if err != nil {
 		return fmt.Errorf("failed to remove snap '%s': %w", s.Name(), err)
 	}

--- a/internal/packages/snap_handler_test.go
+++ b/internal/packages/snap_handler_test.go
@@ -1,31 +1,12 @@
-package handlers
+package packages
 
 import (
 	"os"
 	"reflect"
 	"testing"
 
-	"github.com/jnsgruk/concierge/internal/packages"
 	"github.com/jnsgruk/concierge/internal/runnertest"
 )
-
-func NewTestSnap(name, channel string, classic bool, installed bool) *TestSnap {
-	return &TestSnap{name: name, channel: channel, classic: classic, installed: installed}
-}
-
-type TestSnap struct {
-	name      string
-	channel   string
-	classic   bool
-	installed bool
-}
-
-func (ts *TestSnap) Name() string              { return ts.name }
-func (ts *TestSnap) Classic() (bool, error)    { return ts.classic, nil }
-func (ts *TestSnap) Installed() bool           { return ts.installed }
-func (ts *TestSnap) Tracking() (string, error) { return ts.channel, nil }
-func (ts *TestSnap) Channel() string           { return ts.channel }
-func (ts *TestSnap) SetChannel(c string)       { ts.channel = c }
 
 func TestSnapHandlerCommands(t *testing.T) {
 	type test struct {
@@ -58,10 +39,10 @@ func TestSnapHandlerCommands(t *testing.T) {
 		},
 	}
 
-	snaps := []packages.SnapPackage{
-		NewTestSnap("charmcraft", "latest/stable", true, true),
-		NewTestSnap("jq", "latest/stable", false, false),
-		NewTestSnap("microk8s", "1.30-strict/stable", false, false),
+	snaps := []SnapPackage{
+		runnertest.NewTestSnap("charmcraft", "latest/stable", true, true),
+		runnertest.NewTestSnap("jq", "latest/stable", false, false),
+		runnertest.NewTestSnap("microk8s", "1.30-strict/stable", false, false),
 	}
 
 	for _, tc := range tests {

--- a/internal/providers/google.go
+++ b/internal/providers/google.go
@@ -1,0 +1,78 @@
+package providers
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/runner"
+	"gopkg.in/yaml.v3"
+)
+
+// NewGoogle constructs a new Google provider instance.
+func NewGoogle(runner runner.CommandRunner, config *config.Config) *Google {
+	credentialsFile := config.Providers.Google.CredentialsFile
+	if config.Overrides.GoogleCredentialFile != "" {
+		credentialsFile = config.Overrides.GoogleCredentialFile
+	}
+
+	return &Google{
+		runner:          runner,
+		bootstrap:       config.Providers.Google.Bootstrap,
+		credentialsFile: credentialsFile,
+		credentials:     map[string]interface{}{},
+	}
+}
+
+// Google represents a Google cloud to bootstrap.
+type Google struct {
+	bootstrap       bool
+	runner          runner.CommandRunner
+	credentialsFile string
+	credentials     map[string]interface{}
+}
+
+// Prepare installs and configures Google such that it can work in testing environments.
+// This includes installing the snap, enabling the user who ran concierge to interact
+// with Google without sudo, and deconflicting the firewall rules with docker.
+func (l *Google) Prepare() error {
+	contents, err := l.runner.ReadFile(l.credentialsFile)
+	if err != nil {
+		return fmt.Errorf("failed to read credentials file: %w", err)
+	}
+
+	credentials := make(map[string]interface{})
+
+	err = yaml.Unmarshal(contents, &credentials)
+	if err != nil {
+		return fmt.Errorf("failed to parse google cloud credentials: %w", err)
+	}
+
+	l.credentials = credentials
+
+	slog.Info("Prepared provider", "provider", l.Name())
+	return nil
+}
+
+// Name reports the name of the provider for Concierge's purposes.
+func (l *Google) Name() string { return "google" }
+
+// Bootstrap reports whether a Juju controller should be bootstrapped on Google.
+func (l *Google) Bootstrap() bool { return l.bootstrap }
+
+// CloudName reports the name of the provider as Juju sees it.
+func (l *Google) CloudName() string { return "google" }
+
+// GroupName reports the name of the POSIX group with permissions over the Google socket.
+func (l *Google) GroupName() string { return "" }
+
+// Credentials reports the section of Juju's credentials.yaml for the provider
+func (l *Google) Credentials() map[string]interface{} {
+	return l.credentials
+}
+
+// Remove Google provider.
+func (l *Google) Restore() error {
+	slog.Info("Restored provider", "provider", l.Name())
+	return nil
+}

--- a/internal/providers/google_test.go
+++ b/internal/providers/google_test.go
@@ -1,0 +1,109 @@
+package providers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/runnertest"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNewGoogle(t *testing.T) {
+	type test struct {
+		config   *config.Config
+		expected *Google
+	}
+
+	noOverrides := &config.Config{}
+
+	credsInConfig := &config.Config{}
+	credsInConfig.Providers.Google.CredentialsFile = "/home/ubuntu/credentials.yaml"
+
+	overrides := &config.Config{}
+	overrides.Overrides.GoogleCredentialFile = "/home/ubuntu/alternate-credentials.yaml"
+
+	runner := runnertest.NewMockRunner()
+
+	tests := []test{
+		{
+			config: noOverrides,
+			expected: &Google{
+				runner:      runner,
+				credentials: map[string]interface{}{},
+			},
+		},
+		{
+			config: credsInConfig,
+			expected: &Google{
+				runner:          runner,
+				credentialsFile: "/home/ubuntu/credentials.yaml",
+				credentials:     map[string]interface{}{},
+			},
+		},
+		{
+			config: overrides,
+			expected: &Google{
+				runner:          runner,
+				credentialsFile: "/home/ubuntu/alternate-credentials.yaml",
+				credentials:     map[string]interface{}{},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		uk8s := NewGoogle(runner, tc.config)
+		if !reflect.DeepEqual(tc.expected, uk8s) {
+			t.Fatalf("expected: %v, got: %v", tc.expected, uk8s)
+		}
+	}
+}
+
+func TestGooglePrepareCommands(t *testing.T) {
+	config := &config.Config{}
+	config.Providers.Google.CredentialsFile = "/home/ubuntu/credentials.yaml"
+
+	runner := runnertest.NewMockRunner()
+	uk8s := NewGoogle(runner, config)
+	uk8s.Prepare()
+
+	if len(runner.ExecutedCommands) != 0 {
+		t.Fatalf("expected no commands to have been run")
+	}
+
+	if len(runner.CreatedFiles) != 0 {
+		t.Fatalf("expected no files to have been created")
+	}
+}
+
+func TestGoogleReadCredentials(t *testing.T) {
+	config := &config.Config{}
+	config.Providers.Google.CredentialsFile = "credentials.yaml"
+
+	runner := runnertest.NewMockRunner()
+
+	creds := []byte(`auth-type: oauth2
+client-email: juju-gce-1-sa@concierge.iam.gserviceaccount.com
+client-id: "12345678912345"
+private-key: |
+  -----BEGIN PRIVATE KEY-----
+  deadbeef
+  -----END PRIVATE KEY-----
+project-id: concierge
+`)
+
+	fakeCredsMarshalled := make(map[string]interface{})
+	err := yaml.Unmarshal(creds, &fakeCredsMarshalled)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner.MockFile("credentials.yaml", creds)
+
+	google := NewGoogle(runner, config)
+	google.Prepare()
+
+	if !reflect.DeepEqual(google.Credentials(), fakeCredsMarshalled) {
+		t.Fatalf("expected: %v, got: %v", fakeCredsMarshalled, google.Credentials())
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -34,6 +34,8 @@ func NewProvider(providerName string, runner runner.CommandRunner, config *confi
 		return NewLXD(runner, config)
 	} else if providerName == "microk8s" && config.Providers.MicroK8s.Enable {
 		return NewMicroK8s(runner, config)
+	} else if providerName == "google" && config.Providers.Google.Enable {
+		return NewGoogle(runner, config)
 	} else {
 		return nil
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,8 +1,12 @@
 package providers
 
 import (
-	"github.com/jnsgruk/concierge/internal/packages"
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/runner"
 )
+
+// SupportedProviders is a list of stringified names of supported providers.
+var SupportedProviders []string = []string{"lxd", "microk8s", "google"}
 
 // Provider describes the set of methods expected to be available on a
 // provider that concierge can try to bootstrap Juju onto.
@@ -20,6 +24,17 @@ type Provider interface {
 	// GroupName reports the name of a POSIX user group that can be used
 	// to allow non-root users to interact with the provider (where applicable).
 	GroupName() string
-	// Snaps reports the list of snaps required by the provider.
-	Snaps() []packages.SnapPackage
+	// Credentials reports the section of Juju's credentials.yaml for the provider
+	Credentials() map[string]interface{}
+}
+
+// NewProvider returns a newly constructed provider based on a stringified name of the provider.
+func NewProvider(providerName string, runner runner.CommandRunner, config *config.Config) Provider {
+	if providerName == "lxd" && config.Providers.LXD.Enable {
+		return NewLXD(runner, config)
+	} else if providerName == "microk8s" && config.Providers.MicroK8s.Enable {
+		return NewMicroK8s(runner, config)
+	} else {
+		return nil
+	}
 }

--- a/internal/runner/command.go
+++ b/internal/runner/command.go
@@ -52,7 +52,7 @@ func NewCommandAs(user string, group string, executable string, args []string) *
 func (c *Command) CommandString() string {
 	path, err := exec.LookPath(c.Executable)
 	if err != nil {
-		slog.Warn("Failed to lookup command in path", "command", c.Executable)
+		slog.Debug("Failed to lookup command in path", "command", c.Executable)
 		path = c.Executable
 	}
 

--- a/internal/runner/interface.go
+++ b/internal/runner/interface.go
@@ -15,6 +15,9 @@ type CommandRunner interface {
 	// RunMany takes multiple commands and runs them in sequence, returning an error on the
 	// first error encountered.
 	RunMany(commands ...*Command) error
+	// RunExclusive is a wrapper around Run that uses a mutex to ensure that only one of that
+	// particular command can be run at a time.
+	RunExclusive(c *Command) ([]byte, error)
 	// RunWithRetries executes the command, retrying utilising an exponential backoff pattern,
 	// which starts at 1 second. Retries will be attempted up to the specified maximum duration.
 	RunWithRetries(c *Command, maxDuration time.Duration) ([]byte, error)

--- a/internal/runner/interface.go
+++ b/internal/runner/interface.go
@@ -26,6 +26,8 @@ type CommandRunner interface {
 	MkHomeSubdirectory(subdirectory string) error
 	// RemoveAllHome recursively removes a file path from the user's home directory.
 	RemoveAllHome(filePath string) error
-	// RmHomeDirFile takes a relative file path and removes it from the user's home directory.
+	// ReadHomeDirFile reads a file from the user's home directory.
 	ReadHomeDirFile(filepath string) ([]byte, error)
+	// ReadFile reads a file with an arbitrary path from the system.
+	ReadFile(filePath string) ([]byte, error)
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -150,12 +150,15 @@ func (r *Runner) MkHomeSubdirectory(subdirectory string) error {
 // from the file
 func (r *Runner) ReadHomeDirFile(filePath string) ([]byte, error) {
 	homePath := path.Join(r.user.HomeDir, filePath)
+	return r.ReadFile(homePath)
+}
 
-	if _, err := os.Stat(homePath); errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("file '%s' does not exist: %w", homePath, err)
+// ReadFile takes a path and reads the content from the specified file.
+func (r *Runner) ReadFile(filePath string) ([]byte, error) {
+	if _, err := os.Stat(filePath); errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("file '%s' does not exist: %w", filePath, err)
 	}
-
-	return os.ReadFile(homePath)
+	return os.ReadFile(filePath)
 }
 
 // RemoveAllHome recursively removes a file path from the user's home directory.

--- a/internal/runnertest/mock_runner.go
+++ b/internal/runnertest/mock_runner.go
@@ -1,6 +1,7 @@
 package runnertest
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"time"
@@ -84,6 +85,12 @@ func (r *MockRunner) RunMany(commands ...*runner.Command) error {
 		}
 	}
 	return nil
+}
+
+// RunExclusive is a wrapper around Run that uses a mutex to ensure that only one of that
+// particular command can be run at a time.
+func (r *MockRunner) RunExclusive(c *runner.Command) ([]byte, error) {
+	return r.Run(c)
 }
 
 // WriteHomeDirFile takes a path relative to the real user's home dir, and writes the contents

--- a/internal/runnertest/mock_runner.go
+++ b/internal/runnertest/mock_runner.go
@@ -13,6 +13,7 @@ func NewMockRunner() *MockRunner {
 	return &MockRunner{
 		CreatedFiles: map[string]string{},
 		mockReturns:  map[string]MockCommandReturn{},
+		mockFiles:    map[string][]byte{},
 	}
 }
 
@@ -30,12 +31,18 @@ type MockRunner struct {
 	Deleted            []string
 
 	mockReturns map[string]MockCommandReturn
+	mockFiles   map[string][]byte
 }
 
 // MockCommandReturn sets a static return value representing command combined output,
 // and a desired error return for the specified command.
 func (r *MockRunner) MockCommandReturn(command string, b []byte, err error) {
 	r.mockReturns[command] = MockCommandReturn{Output: b, Error: err}
+}
+
+// MockFile sets a faked expected file contents for a given file.
+func (r *MockRunner) MockFile(filePath string, contents []byte) {
+	r.mockFiles[filePath] = contents
 }
 
 // User returns the user the runner executes commands on behalf of.
@@ -95,8 +102,21 @@ func (r *MockRunner) MkHomeSubdirectory(subdirectory string) error {
 
 // ReadHomeDirFile takes a path relative to the real user's home dir, and reads the content
 // from the file
-func (r *MockRunner) ReadHomeDirFile(filepath string) ([]byte, error) {
-	return nil, nil
+func (r *MockRunner) ReadHomeDirFile(filePath string) ([]byte, error) {
+	val, ok := r.mockFiles[filePath]
+	if !ok {
+		return nil, fmt.Errorf("file not found")
+	}
+	return val, nil
+}
+
+// ReadFile takes a path and reads the content from the specified file.
+func (r *MockRunner) ReadFile(filePath string) ([]byte, error) {
+	val, ok := r.mockFiles[filePath]
+	if !ok {
+		return nil, fmt.Errorf("file not found")
+	}
+	return val, nil
 }
 
 // RemoveAllHome recursively removes a file path from the user's home directory.

--- a/internal/runnertest/mock_snap.go
+++ b/internal/runnertest/mock_snap.go
@@ -1,0 +1,19 @@
+package runnertest
+
+func NewTestSnap(name, channel string, classic bool, installed bool) *TestSnap {
+	return &TestSnap{name: name, channel: channel, classic: classic, installed: installed}
+}
+
+type TestSnap struct {
+	name      string
+	channel   string
+	classic   bool
+	installed bool
+}
+
+func (ts *TestSnap) Name() string              { return ts.name }
+func (ts *TestSnap) Classic() (bool, error)    { return ts.classic, nil }
+func (ts *TestSnap) Installed() bool           { return ts.installed }
+func (ts *TestSnap) Tracking() (string, error) { return ts.channel, nil }
+func (ts *TestSnap) Channel() string           { return ts.channel }
+func (ts *TestSnap) SetChannel(c string)       { ts.channel = c }

--- a/tests/provider-google/concierge.yaml
+++ b/tests/provider-google/concierge.yaml
@@ -1,0 +1,10 @@
+providers:
+  google:
+    enable: true
+    bootstrap: false
+    credentials-file: credentials.yaml
+
+host:
+  snaps:
+    - yq
+    - jq

--- a/tests/provider-google/credentials.yaml
+++ b/tests/provider-google/credentials.yaml
@@ -1,0 +1,8 @@
+auth-type: oauth2
+client-email: juju-gce-1-sa@myname.iam.gserviceaccount.com
+client-id: "1234567891234"
+private-key: |
+  -----BEGIN PRIVATE KEY-----
+  deadbeef
+  -----END PRIVATE KEY-----
+project-id: foobar

--- a/tests/provider-google/task.yaml
+++ b/tests/provider-google/task.yaml
@@ -1,0 +1,17 @@
+summary: Test Google provider writes credentials correctly
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare
+
+  # Match a nested key of the creds file to ensure the map was filled in correctly
+  email="$(cat ~/.local/share/juju/credentials.yaml | yq -r '.credentials.google.concierge.client-email')"
+  echo "$email" | MATCH "juju-gce-1-sa@myname.iam.gserviceaccount.com"
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi


### PR DESCRIPTION
Early ground work for supporting providers for which credentials need to be provided.

First target is Google, but more will be easy to add.

Example config:

```yaml
juju:
  channel: 3.5/stable
  model-defaults:
    test-mode: "true"
    automatically-retry-hooks: "false"
providers:
  google:
    enable: true
    bootstrap: true
    credentials-file: /home/ubuntu/data/temp/google.yaml
```

Example output:

```
ubuntu@ubuntu-noble-2e39:~/data/code/canonical/concierge$ sudo go run . prepare -v --trace
time=2024-10-18T14:03:42.240Z level=INFO msg="Configuration file found" path=concierge.yaml
time=2024-10-18T14:03:42.240Z level=DEBUG msg="Filesystem ownership changed" user=ubuntu group=1000 path=/home/ubuntu/.cache
time=2024-10-18T14:03:42.240Z level=DEBUG msg="Filesystem ownership changed" user=ubuntu group=1000 path=/home/ubuntu/.cache/concierge/concierge.yaml
time=2024-10-18T14:03:42.241Z level=DEBUG msg="Merged runtime configuration saved" path=.cache/concierge/concierge.yaml
time=2024-10-18T14:03:42.241Z level=DEBUG msg="Querying snap install status" snap=juju
time=2024-10-18T14:03:42.248Z level=DEBUG msg="Querying snap confinement" snap=juju
time=2024-10-18T14:03:42.755Z level=DEBUG msg="Running command" command="/usr/bin/snap refresh juju --channel 3.5/stable"
Command: /usr/bin/snap refresh juju --channel 3.5/stable
Output:
snap "juju" has no updates available
time=2024-10-18T14:03:43.047Z level=DEBUG msg="Querying snap channel tracking" snap=juju
time=2024-10-18T14:03:43.051Z level=INFO msg="Refreshed snap" snap=juju channel=3.5/stable
time=2024-10-18T14:03:43.052Z level=INFO msg="Prepared provider" provider=google
time=2024-10-18T14:03:43.052Z level=DEBUG msg="Filesystem ownership changed" user=ubuntu group=1000 path=/home/ubuntu/.local
time=2024-10-18T14:03:43.052Z level=DEBUG msg="Filesystem ownership changed" user=ubuntu group=1000 path=/home/ubuntu/.local
time=2024-10-18T14:03:43.052Z level=DEBUG msg="Filesystem ownership changed" user=ubuntu group=1000 path=/home/ubuntu/.local/share/juju/credentials.yaml
time=2024-10-18T14:03:43.053Z level=DEBUG msg="Running command" user=ubuntu command="sudo -u ubuntu /snap/bin/juju show-controller concierge-google"
Command: sudo -u ubuntu /snap/bin/juju show-controller concierge-google
Output:
{}
ERROR controller concierge-google not found
time=2024-10-18T14:03:43.129Z level=DEBUG msg="Running command" user=ubuntu command="sudo -u ubuntu /snap/bin/juju bootstrap google concierge-google --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true"
Command: sudo -u ubuntu /snap/bin/juju bootstrap google concierge-google --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true
Output:
Adding contents of "/home/ubuntu/.local/share/juju/ssh/juju_id_rsa.pub" to authorized-keys
Creating Juju controller "concierge-google" on google/us-east1
Loading image metadata
Looking for packaged Juju agent version 3.5.4 for amd64
Located Juju agent version 3.5.4-ubuntu-amd64 at https://streams.canonical.com/juju/tools/agent/3.5.4/juju-3.5.4-linux-amd64.tgz
Starting new instance for initial controller
Launching controller instance(s) on google/us-east1...
 - juju-09c8d4-0 (arch=amd64 mem=3.6G cores=4)
Installing Juju agent on bootstrap instance
Waiting for address
Attempting to connect to 35.229.88.157:22
Attempting to connect to 10.142.0.11:22
Connected to 35.229.88.157
Running machine configuration script...
Bootstrap agent now started
Contacting Juju controller at 35.229.88.157 to verify accessibility...

Bootstrap complete, controller "concierge-google" is now available
Controller machines are in the "controller" model

Now you can run
    juju add-model <model-name>
to create a new model to deploy workloads.
time=2024-10-18T14:06:00.105Z level=DEBUG msg="Running command" user=ubuntu command="sudo -u ubuntu /snap/bin/juju add-model -c concierge-google testing"
Command: sudo -u ubuntu /snap/bin/juju add-model -c concierge-google testing
Output:
Added 'testing' model on google/us-east1 with credential 'concierge' for user 'admin'
time=2024-10-18T14:06:02.043Z level=INFO msg="Bootstrapped Juju" provider=google
```