### PR TITLE
feat: add Canonical K8s provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ juju:
 
 # (Required): Define the providers to be installed and bootstrapped.
 providers:
+  # (Optional) Canonical K8s provider configuration.
+  canonical-k8s:
+    # (Optional) Enable or disable Canonical K8s.
+    enable: true | false
+    # (Optional) Whether or not to bootstrap a controller onto Canonical K8s.
+    bootstrap: true | false
+    # (Optional): Channel from which to install Canonical K8s.
+    channel: <channel>
+    # (Optional): Canonical K8s addons to enable.
+    features:
+      # (Optional) Name of the Canonical K8s feature. E.g. `load-balancer`.
+      <feature name>:
+        # (Optional) Feature configuration key/value
+        <key>: <value>
+
   # (Optional) MicroK8s provider configuration.
   microk8s:
     # (Optional) Enable or disable MicroK8s.
@@ -245,9 +260,19 @@ juju:
     automatically-retry-hooks: "false"
 
 providers:
-  microk8s:
+  canonical-k8s:
     enable: true
     bootstrap: true
+    channel: 1.31/candidate
+    features:
+      local-storage:
+      load-balancer:
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+
+  microk8s:
+    enable: false
+    bootstrap: false
     channel: 1.31-strict/stable
     addons:
       - hostpath-storage
@@ -329,7 +354,7 @@ To run any of the tests on a locally provisioned machine, use the `github-ci` ba
 
 ```bash
 # List available tests
-$ spread --list github-ci:
+$ spread -list github-ci:
 # Run all of the tests
 $ spread -v github-ci:
 # Run a particular test

--- a/internal/concierge/plan_validators.go
+++ b/internal/concierge/plan_validators.go
@@ -1,0 +1,27 @@
+package concierge
+
+import (
+	"fmt"
+	"slices"
+)
+
+// planValidators is a list of planValidators used to verify a plan
+var planValidators = []func(p *Plan) error{
+	validateSingleLocalKubernetesInstance,
+}
+
+// validateSingleLocalKubernetesInstance ensures the plan won't try and install multiple
+// local Kubernetes providers, which would conflict.
+func validateSingleLocalKubernetesInstance(plan *Plan) error {
+	providerNames := []string{}
+
+	for _, p := range plan.Providers {
+		providerNames = append(providerNames, p.Name())
+	}
+
+	if slices.Contains(providerNames, "microk8s") && slices.Contains(providerNames, "canonical-k8s") {
+		return fmt.Errorf("cannot configure multiple local kubernetes providers")
+	}
+
+	return nil
+}

--- a/internal/concierge/plan_validators_test.go
+++ b/internal/concierge/plan_validators_test.go
@@ -1,0 +1,39 @@
+package concierge
+
+import (
+	"testing"
+
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/runnertest"
+)
+
+func TestSingleK8sValidator(t *testing.T) {
+	runner := runnertest.NewMockRunner()
+
+	twoK8s := &config.Config{}
+	twoK8s.Providers.CanonicalK8s.Enable = true
+	twoK8s.Providers.MicroK8s.Enable = true
+
+	plan := NewPlan(twoK8s, runner)
+	err := plan.validate()
+	if err == nil {
+		t.Fatalf("should not allow enabling two local kubernetes providers")
+	}
+
+	justCanonicalK8s := &config.Config{}
+	justCanonicalK8s.Providers.CanonicalK8s.Enable = true
+	plan = NewPlan(justCanonicalK8s, runner)
+	err = plan.validate()
+	if err != nil {
+		t.Fatalf("single kubernetes provider should be permitted")
+	}
+
+	justMicroK8s := &config.Config{}
+	justMicroK8s.Providers.MicroK8s.Enable = true
+	plan = NewPlan(justMicroK8s, runner)
+	err = plan.validate()
+	if err != nil {
+		t.Fatalf("single kubernetes provider should be permitted")
+	}
+
+}

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -22,9 +22,10 @@ type jujuConfig struct {
 
 // providerConfig represents the set of providers to be configured and bootstrapped.
 type providerConfig struct {
-	LXD      lxdConfig      `mapstructure:"lxd"`
-	Google   googleConfig   `mapstructure:"google"`
-	MicroK8s microk8sConfig `mapstructure:"microk8s"`
+	CanonicalK8s canonicalK8sConfig `mapstructure:"canonical-k8s"`
+	LXD          lxdConfig          `mapstructure:"lxd"`
+	Google       googleConfig       `mapstructure:"google"`
+	MicroK8s     microk8sConfig     `mapstructure:"microk8s"`
 }
 
 // lxdConfig represents how LXD should be configured on the host.
@@ -47,6 +48,14 @@ type microk8sConfig struct {
 	Bootstrap bool     `mapstructure:"bootstrap"`
 	Channel   string   `mapstructure:"channel"`
 	Addons    []string `mapstructure:"addons"`
+}
+
+// canonicalK8sConfig represents how MicroK8s should be configured on the host.
+type canonicalK8sConfig struct {
+	Enable    bool                         `mapstructure:"enable"`
+	Bootstrap bool                         `mapstructure:"bootstrap"`
+	Channel   string                       `mapstructure:"channel"`
+	Features  map[string]map[string]string `mapstructure:"features"`
 }
 
 // hostConfig is a top-level field containing addition configuration for the host being

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,12 +1,13 @@
 package config
 
 type ConfigOverrides struct {
-	JujuChannel       string
-	MicroK8sChannel   string
-	LXDChannel        string
-	CharmcraftChannel string
-	SnapcraftChannel  string
-	RockcraftChannel  string
+	CanonicalK8sChannel string
+	JujuChannel         string
+	MicroK8sChannel     string
+	LXDChannel          string
+	CharmcraftChannel   string
+	SnapcraftChannel    string
+	RockcraftChannel    string
 
 	GoogleCredentialFile string
 

--- a/internal/providers/canonical-k8s.go
+++ b/internal/providers/canonical-k8s.go
@@ -1,0 +1,168 @@
+package providers
+
+import (
+	"fmt"
+	"log/slog"
+	"path"
+	"time"
+
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/packages"
+	"github.com/jnsgruk/concierge/internal/runner"
+)
+
+// NewCanonicalK8s constructs a new CanonicalK8s provider instance.
+func NewCanonicalK8s(runner runner.CommandRunner, config *config.Config) *CanonicalK8s {
+	var channel string
+
+	if config.Overrides.CanonicalK8sChannel != "" {
+		channel = config.Overrides.CanonicalK8sChannel
+	} else {
+		channel = config.Providers.CanonicalK8s.Channel
+	}
+
+	return &CanonicalK8s{
+		Channel:   channel,
+		Features:  config.Providers.CanonicalK8s.Features,
+		bootstrap: config.Providers.CanonicalK8s.Bootstrap,
+		runner:    runner,
+		snaps: []packages.SnapPackage{
+			packages.NewSnap("k8s", channel),
+			packages.NewSnap("kubectl", "stable"),
+		},
+	}
+}
+
+// CanonicalK8s represents a CanonicalK8s install on a given machine.
+type CanonicalK8s struct {
+	Channel  string
+	Features map[string]map[string]string
+
+	bootstrap bool
+	runner    runner.CommandRunner
+	snaps     []packages.SnapPackage
+}
+
+// Prepare installs and configures Canonical K8s such that it can work in testing environments.
+// This includes installing the snap, enabling the user who ran concierge to interact
+// with CanonicalK8s without sudo, and sets up the user's kubeconfig file.
+func (k *CanonicalK8s) Prepare() error {
+	err := k.install()
+	if err != nil {
+		return fmt.Errorf("failed to install Canonical K8s: %w", err)
+	}
+
+	err = k.init()
+	if err != nil {
+		return fmt.Errorf("failed to install Canonical K8s: %w", err)
+	}
+
+	err = k.configureFeatures()
+	if err != nil {
+		return fmt.Errorf("failed to enable Canonical K8s features: %w", err)
+	}
+
+	err = k.setupKubectl()
+	if err != nil {
+		return fmt.Errorf("failed to setup kubectl for Canonical K8s: %w", err)
+	}
+
+	slog.Info("Prepared provider", "provider", k.Name())
+
+	return nil
+}
+
+// Name reports the name of the provider for Concierge's purposes.
+func (k *CanonicalK8s) Name() string { return "canonical-k8s" }
+
+// Bootstrap reports whether a Juju controller should be bootstrapped onto the provider.
+func (k *CanonicalK8s) Bootstrap() bool { return k.bootstrap }
+
+// CloudName reports the name of the provider as Juju sees it.
+func (k *CanonicalK8s) CloudName() string { return "k8s" }
+
+// GroupName reports the name of the POSIX group with permission to use CanonicalK8s.
+func (k *CanonicalK8s) GroupName() string { return "" }
+
+// Credentials reports the section of Juju's credentials.yaml for the provider
+func (m CanonicalK8s) Credentials() map[string]interface{} { return nil }
+
+// Remove uninstalls CanonicalK8s and kubectl.
+func (k *CanonicalK8s) Restore() error {
+	snapHandler := packages.NewSnapHandler(k.runner, k.snaps)
+
+	err := snapHandler.Restore()
+	if err != nil {
+		return err
+	}
+
+	err = k.runner.RemoveAllHome(".kube")
+	if err != nil {
+		return fmt.Errorf("failed to remove '.kube' from user's home directory: %w", err)
+	}
+
+	slog.Info("Removed provider", "provider", k.Name())
+
+	return nil
+}
+
+// install ensures that CanonicalK8s is installed.
+func (k *CanonicalK8s) install() error {
+	snapHandler := packages.NewSnapHandler(k.runner, k.snaps)
+
+	err := snapHandler.Prepare()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// init ensures that CanonicalK8s is installed, minimally configured, and ready.
+func (k *CanonicalK8s) init() error {
+	cmd := runner.NewCommand("k8s", []string{"bootstrap"})
+	_, err := k.runner.RunWithRetries(cmd, (5 * time.Minute))
+	if err != nil {
+		return err
+	}
+
+	cmd = runner.NewCommand("k8s", []string{"status", "--wait-ready"})
+	_, err = k.runner.RunWithRetries(cmd, (5 * time.Minute))
+
+	return err
+}
+
+// configureFeatures iterates over the specified features, enabling and configuring them.
+func (k *CanonicalK8s) configureFeatures() error {
+	for featureName, conf := range k.Features {
+		for key, value := range conf {
+			featureConfig := fmt.Sprintf("%s.%s=%s", featureName, key, value)
+
+			cmd := runner.NewCommand("k8s", []string{"set", featureConfig})
+			_, err := k.runner.Run(cmd)
+			if err != nil {
+				return fmt.Errorf("failed to set Canonical K8s feature config '%s': %w", featureConfig, err)
+			}
+		}
+
+		cmd := runner.NewCommand("k8s", []string{"enable", featureName})
+		_, err := k.runner.RunWithRetries(cmd, (5 * time.Minute))
+		if err != nil {
+			return fmt.Errorf("failed to enable Canonical K8s addon '%s': %w", featureName, err)
+		}
+	}
+
+	return nil
+}
+
+// setupKubectl both installs the kubectl snap, and writes the relevant kubeconfig
+// file to the user's home directory such that kubectl works with CanonicalK8s.
+func (k *CanonicalK8s) setupKubectl() error {
+	cmd := runner.NewCommand("k8s", []string{"kubectl", "config", "view", "--raw"})
+	result, err := k.runner.Run(cmd)
+	if err != nil {
+		return fmt.Errorf("failed to fetch Canonical K8s configuration: %w", err)
+	}
+
+	return k.runner.WriteHomeDirFile(path.Join(".kube", "config"), result)
+}

--- a/internal/providers/canonical-k8s_test.go
+++ b/internal/providers/canonical-k8s_test.go
@@ -1,0 +1,145 @@
+package providers
+
+import (
+	"os"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/jnsgruk/concierge/internal/packages"
+	"github.com/jnsgruk/concierge/internal/runnertest"
+)
+
+var defaultFeatureConfig = map[string]map[string]string{
+	"load-balancer": {
+		"l2-mode": "true",
+		"cidrs":   "10.43.45.1/32",
+	},
+	"local-storage": {},
+}
+
+func TestNewCanonicalK8s(t *testing.T) {
+	type test struct {
+		config   *config.Config
+		expected *CanonicalK8s
+	}
+
+	noOverrides := &config.Config{}
+
+	channelInConfig := &config.Config{}
+	channelInConfig.Providers.CanonicalK8s.Channel = "1.31/candidate"
+
+	overrides := &config.Config{}
+	overrides.Overrides.CanonicalK8sChannel = "1.32/edge"
+	overrides.Providers.CanonicalK8s.Features = defaultFeatureConfig
+
+	runner := runnertest.NewMockRunner()
+
+	tests := []test{
+		{
+			config:   noOverrides,
+			expected: &CanonicalK8s{Channel: "", runner: runner},
+		},
+		{
+			config:   channelInConfig,
+			expected: &CanonicalK8s{Channel: "1.31/candidate", runner: runner},
+		},
+		{
+			config:   overrides,
+			expected: &CanonicalK8s{Channel: "1.32/edge", Features: defaultFeatureConfig, runner: runner},
+		},
+	}
+
+	for _, tc := range tests {
+		ck8s := NewCanonicalK8s(runner, tc.config)
+
+		// Check the constructed snaps are correct
+		if ck8s.snaps[0].Channel() != tc.expected.Channel {
+			t.Fatalf("expected: %v, got: %v", ck8s.snaps[0].Channel(), tc.expected.Channel)
+		}
+
+		// Remove the snaps so the rest of the object can be compared
+		ck8s.snaps = nil
+		if !reflect.DeepEqual(tc.expected, ck8s) {
+			t.Fatalf("expected: %v, got: %v", tc.expected, ck8s)
+		}
+	}
+}
+
+func TestCanonicalK8sPrepareCommands(t *testing.T) {
+	// Prevent the path of the test machine interfering with the test results.
+	path := os.Getenv("PATH")
+	defer os.Setenv("PATH", path)
+	os.Setenv("PATH", "")
+
+	config := &config.Config{}
+	config.Providers.CanonicalK8s.Channel = ""
+	config.Providers.CanonicalK8s.Features = defaultFeatureConfig
+
+	expectedCommands := []string{
+		"snap install k8s",
+		"k8s bootstrap",
+		"k8s status --wait-ready",
+		"k8s set load-balancer.l2-mode=true",
+		"k8s set load-balancer.cidrs=10.43.45.1/32",
+		"k8s enable load-balancer",
+		"k8s enable local-storage",
+		"k8s kubectl config view --raw",
+	}
+
+	expectedFiles := map[string]string{
+		".kube/config": "",
+	}
+
+	runner := runnertest.NewMockRunner()
+	ck8s := NewCanonicalK8s(runner, config)
+
+	// Override the snaps with fake ones that don't call the snapd socket.
+	ck8s.snaps = []packages.SnapPackage{
+		runnertest.NewTestSnap("k8s", "", false, false),
+	}
+
+	ck8s.Prepare()
+
+	slices.Sort(expectedCommands)
+	slices.Sort(runner.ExecutedCommands)
+
+	if !reflect.DeepEqual(expectedCommands, runner.ExecutedCommands) {
+		t.Fatalf("expected: %v, got: %v", expectedCommands, runner.ExecutedCommands)
+	}
+
+	if !reflect.DeepEqual(expectedFiles, runner.CreatedFiles) {
+		t.Fatalf("expected: %v, got: %v", expectedFiles, runner.CreatedFiles)
+	}
+}
+
+func TestCanonicalK8sRestore(t *testing.T) {
+	// Prevent the path of the test machine interfering with the test results.
+	path := os.Getenv("PATH")
+	defer os.Setenv("PATH", path)
+	os.Setenv("PATH", "")
+
+	config := &config.Config{}
+	config.Providers.CanonicalK8s.Channel = ""
+	config.Providers.CanonicalK8s.Features = defaultFeatureConfig
+
+	runner := runnertest.NewMockRunner()
+	ck8s := NewCanonicalK8s(runner, config)
+	ck8s.Restore()
+
+	expectedDeleted := []string{".kube"}
+
+	if !reflect.DeepEqual(expectedDeleted, runner.Deleted) {
+		t.Fatalf("expected: %v, got: %v", expectedDeleted, runner.Deleted)
+	}
+
+	expectedCommands := []string{
+		"snap remove k8s --purge",
+		"snap remove kubectl --purge",
+	}
+
+	if !reflect.DeepEqual(expectedCommands, runner.ExecutedCommands) {
+		t.Fatalf("expected: %v, got: %v", expectedCommands, runner.ExecutedCommands)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -6,7 +6,12 @@ import (
 )
 
 // SupportedProviders is a list of stringified names of supported providers.
-var SupportedProviders []string = []string{"lxd", "microk8s", "google"}
+var SupportedProviders []string = []string{
+	"canonical-k8s",
+	"google",
+	"lxd",
+	"microk8s",
+}
 
 // Provider describes the set of methods expected to be available on a
 // provider that concierge can try to bootstrap Juju onto.
@@ -36,6 +41,8 @@ func NewProvider(providerName string, runner runner.CommandRunner, config *confi
 		return NewMicroK8s(runner, config)
 	} else if providerName == "google" && config.Providers.Google.Enable {
 		return NewGoogle(runner, config)
+	} else if providerName == "canonical-k8s" && config.Providers.CanonicalK8s.Enable {
+		return NewCanonicalK8s(runner, config)
 	} else {
 		return nil
 	}

--- a/tests/provider-canonical-k8s/concierge.yaml
+++ b/tests/provider-canonical-k8s/concierge.yaml
@@ -1,0 +1,10 @@
+providers:
+  canonical-k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.31/candidate
+    features:
+      local-storage:
+      load-balancer:
+        l2-mode: true
+        cidrs: 10.64.140.43/32

--- a/tests/provider-canonical-k8s/task.yaml
+++ b/tests/provider-canonical-k8s/task.yaml
@@ -1,0 +1,31 @@
+summary: Run concierge with just a MicroK8s provider
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
+
+  list="$(snap list k8s)"
+  echo $list | MATCH k8s
+  echo $list | MATCH 1.31/candidate
+
+  list="$(snap list)"
+  echo $list | MATCH juju
+  echo $list | MATCH kubectl
+
+  sudo k8s status --output-format yaml | yq '.dns.enabled' | MATCH true
+  sudo k8s status --output-format yaml | yq '.load-balancer.enabled' | MATCH true
+  sudo k8s status --output-format yaml | yq '.load-balancer.message' | MATCH "enabled, L2 mode"
+  sudo k8s get | yq '.load-balancer.cidrs' | MATCH "10.64.140.43/32"
+
+  kubectl config current-context | MATCH "k8s"
+
+  juju controllers | tail -n1 | MATCH concierge-canonical-k8s
+  juju models | tail -n1 | MATCH testing
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi


### PR DESCRIPTION
This PR implements support for Canonical K8s as a provider, as the successor to MicroK8s.