### PR TITLE
fix: change default channel for k8s snap to 1.31-classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ sudo concierge prepare -p dev
 
 `concierge` comes with a number of presets that are likely to serve most charm development needs:
 
-| Preset Name | Included                                                         |
-| :---------: | :--------------------------------------------------------------- |
-|    `dev`    | `juju`, `microk8s`, `lxd` `snapcraft`, `charmcraft`, `rockcraft` |
-|    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                  |
-| `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`             |
-|  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                         |
+| Preset Name | Included                                                                  |
+| :---------: | :------------------------------------------------------------------------ |
+|    `dev`    | `juju`, `microk8s`, `lxd` `snapcraft`, `charmcraft`, `rockcraft`, `jhack` |
+|    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
+| `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |
+|  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                  |
 
 Note that in the `microk8s`/`k8s` presets, while `lxd` is installed, it is not bootstrapped. It is
 installed and initialised with enough config such that `charmcraft` can use it as a build backend.

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ providers:
   k8s:
     enable: true
     bootstrap: true
-    channel: 1.31/candidate
+    channel: 1.31-classic/candidate
     features:
       local-storage:
       load-balancer:

--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Default channel from which K8s is installed.
-const defaultK8sChannel = "1.31/candidate"
+const defaultK8sChannel = "1.31-classic/candidate"
 
 // NewK8s constructs a new K8s provider instance.
 func NewK8s(r system.Worker, config *config.Config) *K8s {

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -37,7 +37,7 @@ func TestNewK8s(t *testing.T) {
 	tests := []test{
 		{
 			config:   noOverrides,
-			expected: &K8s{Channel: "1.31/candidate", system: system},
+			expected: &K8s{Channel: "1.31-classic/candidate", system: system},
 		},
 		{
 			config:   channelInConfig,
@@ -71,7 +71,7 @@ func TestK8sPrepareCommands(t *testing.T) {
 	config.Providers.K8s.Features = defaultFeatureConfig
 
 	expectedCommands := []string{
-		"snap install k8s --channel 1.31/candidate",
+		"snap install k8s --channel 1.31-classic/candidate",
 		"snap install kubectl --channel stable",
 		"k8s bootstrap",
 		"k8s status --wait-ready",

--- a/tests/provider-k8s/concierge.yaml
+++ b/tests/provider-k8s/concierge.yaml
@@ -2,7 +2,7 @@ providers:
   k8s:
     enable: true
     bootstrap: true
-    channel: 1.31/candidate
+    channel: 1.31-classic/candidate
     features:
       local-storage:
       load-balancer:

--- a/tests/provider-k8s/task.yaml
+++ b/tests/provider-k8s/task.yaml
@@ -9,7 +9,7 @@ execute: |
 
   list="$(snap list k8s)"
   echo $list | MATCH k8s
-  echo $list | MATCH 1.31/candidate
+  echo $list | MATCH 1.31-classic/candidate
 
   list="$(snap list)"
   echo $list | MATCH juju


### PR DESCRIPTION
concierge by default attempts to install the k8s snap at 1.31/candidate, but no such release exists:

![image](https://github.com/user-attachments/assets/812d04e9-8866-4152-b842-13cd7c27392d)

changed all defaults to install 1.31-classic instead.