### PR TITLE
fix: Log command output on failure

### DIFF
--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -68,7 +68,7 @@ func (s *System) Run(c *Command) ([]byte, error) {
 
 	output, err := cmd.CombinedOutput()
 
-	if s.trace {
+	if s.trace || err != nil {
 		fmt.Print(generateTraceMessage(c.CommandString(), output))
 	}
 


### PR DESCRIPTION
This proposed change generates a trace of a failing command automatically, even if tracing is disabled.

This would be useful when running in CI. Recently, I have seen `concierge` fail to install LXD with this simple log line:

```
time=2024-11-18T20:55:23.847Z level=ERROR msg="Failed to configure machine" error="failed to install LXD: failed to install snap: command failed: exit status 1"
```

The error does not happen consistently, and the error message in that case is not useful.