### PR TITLE
fix: ensure `network` is enabled for k8s presets

### DIFF
--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -68,6 +68,7 @@ var defaultK8sConfig k8sConfig = k8sConfig{
 			"cidrs":   "10.43.45.0/28",
 		},
 		"local-storage": {},
+		"network":       {},
 	},
 }
 

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -16,6 +16,7 @@ var defaultFeatureConfig = map[string]map[string]string{
 		"cidrs":   "10.43.45.1/32",
 	},
 	"local-storage": {},
+	"network":       {},
 }
 
 func TestNewK8s(t *testing.T) {
@@ -81,6 +82,7 @@ func TestK8sPrepareCommands(t *testing.T) {
 		"k8s set load-balancer.cidrs=10.43.45.1/32",
 		"k8s enable load-balancer",
 		"k8s enable local-storage",
+		"k8s enable network",
 		"k8s kubectl config view --raw",
 	}
 
@@ -120,6 +122,7 @@ func TestK8sPrepareCommandsAlreadyBootstrapped(t *testing.T) {
 		"k8s set load-balancer.cidrs=10.43.45.1/32",
 		"k8s enable load-balancer",
 		"k8s enable local-storage",
+		"k8s enable network",
 		"k8s kubectl config view --raw",
 	}
 


### PR DESCRIPTION
Follow up to #17.

Previously, if K8s was already installed but not configured with the `network` feature enabled, the `concierge` presets would not enable the `network` feature explicitly - causing the load balancer configuration to fail.

This change ensures that for the *presets* using k8s, `network` is explicitly enabled.