### PR TITLE
feat: add `concierge status` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Available Commands:
   help        Help about any command
   prepare     Provision the machine according to the configuration.
   restore     Run the reverse of `concierge prepare`.
+  status      Report the status of `concierge` on the machine.
 
 Flags:
   -h, --help      help for concierge

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,7 +20,7 @@ func Execute() {
 
 	err := cmd.Execute()
 	if err != nil {
-		slog.Error("Failed to configure machine", "error", err.Error())
+		slog.Error("concierge failed", "error", err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ tools from the [snap store](https://snapcraft.io) or the Ubuntu archive.
 
 	cmd.AddCommand(restoreCmd())
 	cmd.AddCommand(prepareCmd())
+	cmd.AddCommand(statusCmd())
 
 	return cmd
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jnsgruk/concierge/internal/concierge"
+	"github.com/jnsgruk/concierge/internal/config"
+	"github.com/spf13/cobra"
+)
+
+// statusCmd reports the status of concierge provisioning on a machine.
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Report the status of `concierge` on the machine.",
+		Long: `Report the status of 'concierge' on the machine.
+
+Reports one of 'provisioning', 'succeeded' or 'failed'.
+		`,
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			parseLoggingFlags(cmd.Flags())
+			return checkUser()
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+
+			conf, err := config.NewConfig(cmd, flags)
+			if err != nil {
+				return fmt.Errorf("failed to configure concierge: %w", err)
+			}
+
+			mgr, err := concierge.NewManager(conf)
+			if err != nil {
+				return err
+			}
+
+			status, err := mgr.Status()
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("%s\n", status)
+			return nil
+		},
+	}
+}

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -8,8 +8,23 @@ type Config struct {
 
 	// The following are added at runtime according to CLI flags
 	Overrides ConfigOverrides `mapstructure:"overrides"`
+	Status    Status          `mapstructure:"status"`
 	Verbose   bool            `mapstructure:"verbose"`
 	Trace     bool            `mapstructure:"trace"`
+}
+
+// Status represents the status of concierge on a given machine.
+type Status int
+
+const (
+	Provisioning Status = iota
+	Succeeded
+	Failed
+)
+
+// String returns a string representation of a given concierge status.
+func (s Status) String() string {
+	return [...]string{"provisioning", "succeeded", "failed"}[s]
 }
 
 // jujuConfig represents the configuration for juju, including the desired version,

--- a/tests/status-failed/concierge.yaml
+++ b/tests/status-failed/concierge.yaml
@@ -1,0 +1,12 @@
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 2G

--- a/tests/status-failed/task.yaml
+++ b/tests/status-failed/task.yaml
@@ -1,0 +1,15 @@
+summary: Ensure failed status is reported correctly
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="foobarbazquzquxfail" || true
+
+  "$SPREAD_PATH"/concierge status | MATCH failed
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi

--- a/tests/status-success/concierge.yaml
+++ b/tests/status-success/concierge.yaml
@@ -1,0 +1,12 @@
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 2G

--- a/tests/status-success/task.yaml
+++ b/tests/status-success/task.yaml
@@ -1,0 +1,15 @@
+summary: Ensure successful status is reported correctly
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare --extra-snaps="yq"
+
+  "$SPREAD_PATH"/concierge status | MATCH succeeded
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi


### PR DESCRIPTION
Adds a command that can be used to check whether or not concierge has succeeded, failed or is in progress on a machine.

Fixes #31 