### PR TITLE
feat: ability to disable juju install/bootstrap entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ sudo concierge prepare -p dev
 
 | Preset Name | Included                                                                  |
 | :---------: | :------------------------------------------------------------------------ |
+|  `crafts`   | `lxd` `snapcraft`, `charmcraft`, `rockcraft`                              |
 |    `dev`    | `juju`, `microk8s`, `lxd` `snapcraft`, `charmcraft`, `rockcraft`, `jhack` |
 |    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
 | `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ the environment variable version will always take precedent. The equivalents are
 
 |            Flag            |              Env Var               |
 | :------------------------: | :--------------------------------: |
+|      `--disable-juju`      |      `CONCIERGE_DISABLE_JUJU`      |
 |      `--juju-channel`      |      `CONCIERGE_JUJU_CHANNEL`      |
 |      `--k8s-channel`       |      `CONCIERGE_K8S_CHANNEL`       |
 |    `--microk8s-channel`    |    `CONCIERGE_MICROK8S_CHANNEL`    |

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -61,6 +61,7 @@ More information at https://github.com/jnsgruk/concierge.
 	flags := cmd.Flags()
 	flags.StringP("config", "c", "", "path to a specific config file to use")
 	flags.StringP("preset", "p", "", "config preset to use (k8s | machine | dev)")
+	flags.Bool("disable-juju", false, "disable the installation and bootstrap of juju")
 	flags.String("juju-channel", "", "override the snap channel for juju")
 	flags.String("k8s-channel", "", "override snap channel for the k8s snap")
 	flags.String("microk8s-channel", "", "override snap channel for microk8s")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -105,6 +105,7 @@ func parseConfig(configFile string) (*Config, error) {
 // ConfigOverrides struct.
 func getOverrides(flags *pflag.FlagSet) ConfigOverrides {
 	return ConfigOverrides{
+		DisableJuju:       envOrFlagBool(flags, "disable-juju"),
 		JujuChannel:       envOrFlagString(flags, "juju-channel"),
 		K8sChannel:        envOrFlagString(flags, "k8s-channel"),
 		MicroK8sChannel:   envOrFlagString(flags, "microk8s-channel"),
@@ -118,6 +119,15 @@ func getOverrides(flags *pflag.FlagSet) ConfigOverrides {
 		ExtraSnaps: envOrFlagSlice(flags, "extra-snaps"),
 		ExtraDebs:  envOrFlagSlice(flags, "extra-debs"),
 	}
+}
+
+// envOrFlagBool returns a boolean config value set from env var or flag, priority on env var.
+func envOrFlagBool(flags *pflag.FlagSet, key string) bool {
+	value, _ := flags.GetBool(key)
+	if v := viper.GetBool(key); v {
+		value = v
+	}
+	return value
 }
 
 // envOrFlagString returns a string config value set from env var or flag, priority on env var.

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -30,6 +30,9 @@ func (s Status) String() string {
 // jujuConfig represents the configuration for juju, including the desired version,
 // and defaults/constraints for the bootstrap process.
 type jujuConfig struct {
+	// Optionally disable the installation of Juju
+	Disable bool `mapstructure:"disable"`
+	// The Snap Store channel from which to install Juju
 	Channel string `mapstructure:"channel"`
 	// The set of model-defaults to be passed to Juju during bootstrap
 	ModelDefaults map[string]string `mapstructure:"model-defaults"`

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -1,6 +1,7 @@
 package config
 
 type ConfigOverrides struct {
+	DisableJuju       bool
 	K8sChannel        string
 	JujuChannel       string
 	MicroK8sChannel   string

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -20,6 +20,7 @@ func Preset(preset string) (*Config, error) {
 
 // defaultJujuConfig is the default Juju config for all presets.
 var defaultJujuConfig jujuConfig = jujuConfig{
+	Disable: false,
 	ModelDefaults: map[string]string{
 		"test-mode":                 "true",
 		"automatically-retry-hooks": "false",

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -13,6 +13,8 @@ func Preset(preset string) (*Config, error) {
 		return machinePreset, nil
 	case "dev":
 		return devPreset, nil
+	case "crafts":
+		return craftsPreset, nil
 	default:
 		return nil, fmt.Errorf("unknown preset '%s'", preset)
 	}
@@ -136,6 +138,24 @@ var devPreset *Config = &Config{
 			"rockcraft": {Channel: "latest/stable"},
 			"snapcraft": {Channel: "latest/stable"},
 			"jhack":     {Channel: "latest/stable", Connections: []string{"jhack:dot-local-share-juju"}},
+		}),
+	},
+}
+
+// craftsPreset installs each of the crafts, and configures LXD, but disables Juju.
+// Useful for workflows where only artifacts need to be built.
+var craftsPreset *Config = &Config{
+	Juju: jujuConfig{
+		Disable: true,
+	},
+	Providers: providerConfig{
+		LXD: defaultLXDConfig,
+	},
+	Host: hostConfig{
+		Packages: defaultPackages,
+		Snaps: MergeMaps(defaultSnaps, map[string]SnapConfig{
+			"rockcraft": {Channel: "latest/stable"},
+			"snapcraft": {Channel: "latest/stable"},
 		}),
 	},
 }

--- a/tests/disable-juju-config/concierge.yaml
+++ b/tests/disable-juju-config/concierge.yaml
@@ -1,0 +1,7 @@
+juju:
+  disable: true
+providers:
+  lxd:
+    enable: true
+    bootstrap: true
+    channel: latest/stable

--- a/tests/disable-juju-config/task.yaml
+++ b/tests/disable-juju-config/task.yaml
@@ -1,0 +1,19 @@
+summary: Run concierge with just a LXD provider with Juju disabled in config
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare
+
+  list="$(snap list lxd)"
+  echo $list | MATCH lxd
+  echo $list | MATCH latest/stable
+
+  snap list | NOMATCH juju
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi

--- a/tests/disable-juju-env-var/task.yaml
+++ b/tests/disable-juju-env-var/task.yaml
@@ -1,0 +1,19 @@
+summary: Run concierge with the k8s preset, but disable Juju with an env var override
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  export CONCIERGE_DISABLE_JUJU=true
+  "$SPREAD_PATH"/concierge --trace prepare --preset k8s
+
+  list="$(snap list lxd)"
+  echo $list | MATCH lxd
+
+  snap list | NOMATCH juju
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi

--- a/tests/disable-juju-flag/task.yaml
+++ b/tests/disable-juju-flag/task.yaml
@@ -1,0 +1,18 @@
+summary: Run concierge with the machine preset, but disable juju with a flag
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare --preset machine --disable-juju
+
+  list="$(snap list lxd)"
+  echo $list | MATCH lxd
+
+  snap list | NOMATCH juju
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi

--- a/tests/preset-crafts/task.yaml
+++ b/tests/preset-crafts/task.yaml
@@ -1,0 +1,20 @@
+summary: Run concierge with the crafts preset
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  "$SPREAD_PATH"/concierge --trace prepare -p crafts
+
+  # Check that relevant snaps are installed
+  for s in lxd jq yq charmcraft rockcraft snapcraft; do
+    snap list "$s" | MATCH $s
+  done
+
+  snap list | NOMATCH juju
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi


### PR DESCRIPTION
This PR adds to option for Juju to be *explicitly disabled* as part of the provisioning.

Concierge was initially imagined as a tool to build test environments for charms, and as such I think it's default should be to make Juju available.

That said there are examples of situations where `concierge` is useful, but Juju is not required. #27 is one such example of that, but there may be other situations where using `concierge` to provision Canonical K8s in CI is desirable, but Juju is not required.

Contrary to the providers, which have an `Enable` option, this PR introduces `Juju.Disable` so as to make it explicit to *opt out* of Juju, rather than make Juju opt in.

tl;dr `concierge prepare -p k8s --disable-juju` or similar.

Drive by to add a `crafts` preset which fixes #27, given that the ability to disable Juju makes it trivial to add.