### PR TITLE
docs: correct the choices in the dev preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo concierge prepare -p dev
 
 | Preset Name | Included                                                                  |
 | :---------: | :------------------------------------------------------------------------ |
-|  `crafts`   | `lxd` `snapcraft`, `charmcraft`, `rockcraft`                              |
+|  `crafts`   | `lxd`, `snapcraft`, `charmcraft`, `rockcraft`                             |
 |    `dev`    | `juju`, `k8s`, `lxd`, `snapcraft`, `charmcraft`, `rockcraft`, `jhack`     |
 |    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
 | `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ sudo concierge prepare -p dev
 | Preset Name | Included                                                                  |
 | :---------: | :------------------------------------------------------------------------ |
 |  `crafts`   | `lxd` `snapcraft`, `charmcraft`, `rockcraft`                              |
-|    `dev`    | `juju`, `microk8s`, `lxd` `snapcraft`, `charmcraft`, `rockcraft`, `jhack` |
+|    `dev`    | `juju`, `k8s`, `lxd`, `snapcraft`, `charmcraft`, `rockcraft`, `jhack`     |
 |    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
 | `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |
 |  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                  |


### PR DESCRIPTION
The `dev` preset [installs k8s, not microk8s](https://github.com/jnsgruk/concierge/blob/1668e372c9f63bc1a57113af512cb000772569f6/internal/config/presets.go#L133).

Also adds a couple of missing commas.