### PR TITLE
feat: show time taken to run each command in --verbose mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /concierge
 dist/
 .spread-reuse*.yaml
+/.idea

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Or you can clone, build and run like so:
 ```shell
 git clone https://github.com/jnsgruk/concierge
 cd concierge
-go build -o concierge main.go
+go build
 sudo ./concierge -h
 ```
 
@@ -367,7 +367,7 @@ git clone https://github.com/jnsgruk/concierge
 cd concierge
 
 # Build/run with Go
-go run main.go
+go run .
 
 # Run the unit tests
 go test ./...

--- a/internal/system/runner.go
+++ b/internal/system/runner.go
@@ -62,14 +62,19 @@ func (s *System) Run(c *Command) ([]byte, error) {
 		return nil, fmt.Errorf("unable to determine shell path to run command")
 	}
 
-	cmd := exec.Command(shell, "-c", c.CommandString())
+	commandString := c.CommandString()
+	cmd := exec.Command(shell, "-c", commandString)
 
-	logger.Debug("Running command", "command", c.CommandString())
+	logger.Debug("Starting command", "command", commandString)
 
+	start := time.Now()
 	output, err := cmd.CombinedOutput()
 
+	elapsed := time.Since(start)
+	logger.Debug("Finished command", "command", commandString, "elapsed", elapsed)
+
 	if s.trace || err != nil {
-		fmt.Print(generateTraceMessage(c.CommandString(), output))
+		fmt.Print(generateTraceMessage(commandString, output))
 	}
 
 	return output, err


### PR DESCRIPTION
Adding this so it's a bit easier to see what commands take the most time (maybe in future we can speed up some things).

Change "Running" to "Starting", mainly so it's the same width as "Finished" and these logs come out aligned nicely like so:

```
time=2025-03-06T17:17:28.505+13:00 level=DEBUG msg="Starting command" command="/usr/bin/sleep 1.23" 
time=2025-03-06T17:17:29.738+13:00 level=DEBUG msg="Finished command" command="/usr/bin/sleep 1.23" elapsed=1.232700868s
```

Also tweak a couple of other things:

- Add .idea to .gitignore for GoLand IDE
- Simplify "go build" and "go run" commands in README.md (these args are implied)