### PR TITLE
ci: add SBOM generation and secscan run to publish workflow

### DIFF
--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -10,9 +10,7 @@ clients:
 artifacts:
   - name: 'concierge'
     type: 'snap'
-    version: '40'
     ssdlc_params:
         name: 'concierge'
-        version: '40'
         channel: 'stable'
         cycle: '25.10'

--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -12,5 +12,6 @@ artifacts:
     type: 'snap'
     ssdlc_params:
         name: 'concierge'
+        version: ''
         channel: 'stable'
         cycle: '25.10'

--- a/.github/.sbomber-manifest.yaml
+++ b/.github/.sbomber-manifest.yaml
@@ -1,0 +1,18 @@
+clients:
+  sbom:
+      service_url: https://sbom-request.canonical.com
+      department: charm_engineering
+      email: tony.meyer@canonical.com
+      team: charm_tech
+  secscan: {}
+
+
+artifacts:
+  - name: 'concierge'
+    type: 'snap'
+    version: '40'
+    ssdlc_params:
+        name: 'concierge'
+        version: '40'
+        channel: 'stable'
+        cycle: '25.10'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,4 +139,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
 
   secscan:
-    uses: .github/workflows/secscan.yaml
+    uses: ./.github/workflows/secscan.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -137,3 +137,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
+
+  secscan:
+    uses: .github/workflows/secscan.yaml

--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -1,0 +1,58 @@
+name: SBOM and secscan
+
+on:
+    workflow_call:
+    workflow_dispatch:
+
+permissions: {}
+
+jobs:
+    scan:
+        strategy:
+          fail-fast: false
+
+        name: SBOM generation
+        runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@v4
+            with:
+              persist-credentials: false
+          - name: Install dependencies
+            run: |
+              sudo apt-get update
+              sudo apt-get install -y libapt-pkg-dev
+              sudo apt install -y python3-apt
+          - name: Checkout security scanner
+            uses: actions/checkout@v4
+            with:
+              repository: canonical/sbomber
+              path: scanner
+              token: ${{ secrets.SBOMBER_TOKEN }}
+              persist-credentials: false
+          - name: Install uv
+            uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0
+          - name: Install secscan cli
+            run: |
+              sudo snap install canonical-secscan-client
+              sudo snap connect canonical-secscan-client:home system:home
+          - name: Prepare the artifacts
+            run: |
+              cd scanner
+              ./sbomber prepare ../.github/.sbomber-manifest.yaml
+          - name: Submit the artifacts
+            run: |
+              cd scanner
+              ./sbomber submit
+          - name: Wait for the scans to finish
+            run: |
+              cd scanner
+              ./sbomber poll --wait --timeout 30
+          - name: Download the reports
+            run: |
+              cd scanner && ./sbomber download
+          - name: Upload reports
+            uses: actions/upload-artifact@v4
+            with:
+              name: secscan-report-upload
+              path: ./scanner/reports/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist/
 /.idea
 # sbomber tool
 .statefile.yaml
+pkgs/
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dist/
 # sbomber tool
 .statefile.yaml
 pkgs/
-
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 dist/
 .spread-reuse*.yaml
 /.idea
+# sbomber tool
+.statefile.yaml
+


### PR DESCRIPTION
At the conclusion of the publishing workflow, use the secscan tool to generate an SBOM and run a security scan, and store those results with the workflow.

Although there's only a single artefact to run against, the workflow uses the [sbomber](https://github.com/canonical/sbomber) tool to simplify the process and keep it consistent with other Charm Tech projects.

The secscan tool can only be run in the Canonical network, so the workflow is set to use a hosted runner. This prevents testing the workflow in my fork, but it is very similar to the one in canonical/operator that works.

TODO:
* [ ] Once we hear back from the security team, either add in the required secret to get sbomber package, or (hopefully) remove that requirement.
* [x] Investigate automatically pulling the version information.