### PR TITLE
docs: extend the security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,7 +37,14 @@ expect from you.
 
 ## Cryptographic technology
 
-Concierge does not directly use any cryptographic technology, hashing, or digital signatures.
+Concierge uses cryptographic technology to securely download Snaps and Debian packages from the Ubuntu archive to install. Some of those tools, such as Juju, will in turn use crytographic technology to securely download images and other data needed to initialise.
+
+Concierge uses `apt` to install Debian packages, and Snap (via the [snapcore/snapd library](https://github.com/canonical/snapd))) to install Snaps.
+
+> See more:
+>  - [Debian | SecureApt](https://wiki.debian.org/SecureApt)
+>  - [Ubuntu Community | SecureApt](https://help.ubuntu.com/community/SecureApt)
+>  - [Snap | Cryptography](https://snapcraft.io/docs/security-policies#p-2741-cryptography)
 
 ## Hardening
 
@@ -56,3 +63,8 @@ Concierge does not add any risks over manually installing and configuring the Sn
 >  - [Juju Security](https://documentation.ubuntu.com/juju/3.6/explanation/juju-security/)
 >  - [LXD Security](https://documentation.ubuntu.com/lxd/stable-5.21/explanation/security/)
 >  - [Canonical K8s Security](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/howto/security/)
+
+
+## Good practice
+
+If you are [providing credentials to Concierge](https://github.com/canonical/concierge/?tab=readme-ov-file#providing-credentials-files) for clouds, ensure that these are stored securely.


### PR DESCRIPTION
Extends the SECURITY.md doc to include content that would normally be found in a Security doc in the Explanation section. If Concierge gains a documentation site, or documentation on Concierge is added to another site (e.g. Ops) then this content could move there at that time.

Adds information on:

* Cryptography use (particularly links to the actual use by `apt` and `snap`)
* Hardening (not required)
* Security risks introduced/changed when using Concierge (none)

I've looked for security and hardening information for the various packages that Concierge uses, to link to it. Unfortunately, many of them do not (yet) have any available. I've included the ones that do.

The goal is for this doc to be generally useful for charm authors, but also to comply with [SEC0030](https://docs.google.com/document/d/12_hj3_xhaYWqKHsmnuRl5wQO3Es4GuHWtgrxMHG21FM/edit?tab=t.0#heading=h.jszeo1fa8onu) and [Canonical product security documentation guidance](https://docs.google.com/document/d/1QBVUxfOVaTXEbBUiiWMzYHiAxG79NIGS7YTVX_GNE4Q/edit?tab=t.0#heading=h.ikq8mvhgar8v).

[Preview](https://github.com/tonyandrewmeyer/concierge/blob/extend-security-doc/SECURITY.md)