### PR TITLE
feat(provider): add microceph

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ the environment variable version will always take precedent. The equivalents are
 |      `--juju-channel`      |      `CONCIERGE_JUJU_CHANNEL`      |
 |      `--k8s-channel`       |      `CONCIERGE_K8S_CHANNEL`       |
 |    `--microk8s-channel`    |    `CONCIERGE_MICROK8S_CHANNEL`    |
+|    `--microceph-channel`   |    `CONCIERGE_MICROCEPH_CHANNEL`   |
 |      `--lxd-channel`       |      `CONCIERGE_LXD_CHANNEL`       |
 |   `--charmcraft-channel`   |   `CONCIERGE_CHARMCRAFT_CHANNEL`   |
 |   `--snapcraft-channel`    |   `CONCIERGE_SNAPCRAFT_CHANNEL`    |
@@ -113,6 +114,18 @@ export CONCIERGE_JUJU_CHANNEL=3.6/beta
 sudo concierge prepare -p dev
 ```
 
+3. Set up S3-compatible object storage using the `storage` preset:
+
+```bash
+# Install with default settings
+sudo concierge prepare -p storage
+
+# Or specify a different channel for microceph
+sudo concierge prepare -p storage --microceph-channel=latest/edge
+
+# After installation, create S3 buckets using s3cmd (auto-installed)
+s3cmd --host=localhost:8080 --access_key=access-key --secret_key=secret-key --host-bucket= --no-ssl mb s3://mybucket
+
 ## Configuration
 
 ### Presets
@@ -126,6 +139,7 @@ sudo concierge prepare -p dev
 |    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
 | `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |
 |  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                  |
+| `storage`   | `juju`, `lxd`, `microceph`                   |
 
 Note that in the `microk8s`/`k8s` presets, while `lxd` is installed, it is not bootstrapped. It is
 installed and initialised with enough config such that `charmcraft` can use it as a build backend.
@@ -209,6 +223,13 @@ providers:
     # (Optional): A map of bootstrap-constraints to set when bootstrapping the Juju controller.
     bootstrap-constraints:
       <bootstrap-constraint>: <value>
+
+  # (Optional) MicroCeph provider configuration.
+  microceph:
+    # (Optional) Enable or disable MicroCeph.
+    enable: true | false
+    # (Optional): Channel from which to install MicroCeph.
+    channel: <channel>
 
   # (Optional) Google provider configuration.
   google:
@@ -341,6 +362,10 @@ providers:
     enable: true
     bootstrap: false
     credentials-file: /home/ubuntu/google-credentials.yaml
+
+  microceph:
+    enable: true
+    channel: latest/stable  # Will provide S3-compatible object storage on ports 8080/8443
 
 host:
   packages:

--- a/cmd/prepare.go
+++ b/cmd/prepare.go
@@ -65,6 +65,7 @@ More information at https://github.com/canonical/concierge.
 	flags.String("juju-channel", "", "override the snap channel for juju")
 	flags.String("k8s-channel", "", "override snap channel for the k8s snap")
 	flags.String("microk8s-channel", "", "override snap channel for microk8s")
+	flags.String("microceph-channel", "", "override snap channel for microceph")
 	flags.String("lxd-channel", "", "override snap channel for lxd")
 	flags.String("charmcraft-channel", "", "override snap channel for charmcraft")
 	flags.String("snapcraft-channel", "", "override snap channel for snapcraft")

--- a/internal/concierge/plan.go
+++ b/internal/concierge/plan.go
@@ -138,6 +138,8 @@ func getSnapChannelOverride(config *config.Config, snap string) string {
 		return config.Overrides.SnapcraftChannel
 	case "rockcraft":
 		return config.Overrides.RockcraftChannel
+	case "microceph":
+		return config.Overrides.MicroCephChannel
 	default:
 		return ""
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,7 @@ func getOverrides(flags *pflag.FlagSet) ConfigOverrides {
 		CharmcraftChannel: envOrFlagString(flags, "charmcraft-channel"),
 		SnapcraftChannel:  envOrFlagString(flags, "snapcraft-channel"),
 		RockcraftChannel:  envOrFlagString(flags, "rockcraft-channel"),
+		MicroCephChannel:  envOrFlagString(flags, "microceph-channel"),
 
 		GoogleCredentialFile: envOrFlagString(flags, "google-credential-file"),
 

--- a/internal/config/config_format.go
+++ b/internal/config/config_format.go
@@ -48,6 +48,7 @@ type providerConfig struct {
 	LXD      lxdConfig      `mapstructure:"lxd"`
 	Google   googleConfig   `mapstructure:"google"`
 	MicroK8s microk8sConfig `mapstructure:"microk8s"`
+	MicroCeph microcephConfig `mapstructure:"microceph"`
 }
 
 // lxdConfig represents how LXD should be configured on the host.
@@ -76,6 +77,12 @@ type microk8sConfig struct {
 	Addons               []string          `mapstructure:"addons"`
 	ModelDefaults        map[string]string `mapstructure:"model-defaults"`
 	BootstrapConstraints map[string]string `mapstructure:"bootstrap-constraints"`
+}
+
+// microcephConfig represents how MicroCeph (microceph snap) should be configured on the host.
+type microcephConfig struct {
+	Enable  bool   `mapstructure:"enable"`
+	Channel string `mapstructure:"channel"`
 }
 
 // k8sConfig represents how MicroK8s should be configured on the host.

--- a/internal/config/overrides.go
+++ b/internal/config/overrides.go
@@ -9,6 +9,7 @@ type ConfigOverrides struct {
 	CharmcraftChannel string
 	SnapcraftChannel  string
 	RockcraftChannel  string
+	MicroCephChannel  string
 
 	GoogleCredentialFile string
 

--- a/internal/config/presets.go
+++ b/internal/config/presets.go
@@ -15,6 +15,8 @@ func Preset(preset string) (*Config, error) {
 		return devPreset, nil
 	case "crafts":
 		return craftsPreset, nil
+	case "storage":
+		return storagePreset, nil
 	default:
 		return nil, fmt.Errorf("unknown preset '%s'", preset)
 	}
@@ -72,6 +74,26 @@ var defaultK8sConfig k8sConfig = k8sConfig{
 		},
 		"local-storage": {},
 		"network":       {},
+	},
+}
+
+// defaultMicroCephConfig is the standard MicroCeph config used throughout presets.
+var defaultMicroCephConfig microcephConfig = microcephConfig{
+	Enable:  true,
+	Channel: "latest/stable",
+}
+
+// storagePreset is a configuration preset designed to be used when testing
+// charms that need S3-compatible object storage.
+var storagePreset *Config = &Config{
+	Juju: defaultJujuConfig,
+	Providers: providerConfig{
+		LXD:      lxdConfig{Enable: true},
+		MicroCeph: defaultMicroCephConfig,
+	},
+	Host: hostConfig{
+		Packages: defaultPackages,
+		Snaps:    defaultSnaps,
 	},
 }
 

--- a/internal/providers/microceph.go
+++ b/internal/providers/microceph.go
@@ -1,0 +1,138 @@
+package providers
+
+import (
+    "fmt"
+    "log/slog"
+    "time"
+
+    "github.com/canonical/concierge/internal/config"
+    "github.com/canonical/concierge/internal/packages"
+    "github.com/canonical/concierge/internal/system"
+)
+
+// default channel if none specified
+const defaultMicroCephChannel = "latest/stable"
+
+// NewMicroCeph constructs a new MicroCeph provider instance.
+func NewMicroCeph(r system.Worker, config *config.Config) *MicroCeph {
+    channel := config.Providers.MicroCeph.Channel
+    if config.Overrides.MicroCephChannel != "" {
+        channel = config.Overrides.MicroCephChannel
+    }
+    if channel == "" {
+        channel = defaultMicroCephChannel
+    }
+
+    return &MicroCeph{
+        Channel: channel,
+        system:  r,
+        snaps: []*system.Snap{
+            {Name: "microceph", Channel: channel},
+        },
+    }
+}
+
+// MicroCeph represents a microceph installation used to provide RADOSGW/S3.
+type MicroCeph struct {
+    Channel string
+
+    system system.Worker
+    snaps  []*system.Snap
+}
+
+// Prepare installs and configures microceph and radosgw for S3 access.
+func (m *MicroCeph) Prepare() error {
+    // Install the snap
+    snapHandler := packages.NewSnapHandler(m.system, m.snaps)
+    if err := snapHandler.Prepare(); err != nil {
+        return fmt.Errorf("failed to install microceph snap: %w", err)
+    }
+
+    // Bootstrap the cluster
+    cmd := system.NewCommand("microceph", []string{"cluster", "bootstrap"})
+    if _, err := m.system.RunWithRetries(cmd, 2*time.Minute); err != nil {
+        return fmt.Errorf("failed to bootstrap microceph cluster: %w", err)
+    }
+
+    // Add a loop disk (4G, 3 devices) — best-effort
+    cmd = system.NewCommand("microceph", []string{"disk", "add", "loop,4G,3"})
+    if _, err := m.system.RunWithRetries(cmd, 1*time.Minute); err != nil {
+        // Log and continue — disks may already be added or not required
+        slog.Warn("microceph: failed to add loop disk, continuing", "error", err)
+    }
+
+    // Wait for ceph to settle
+    cmd = system.NewCommand("microceph.ceph", []string{"-s"})
+    if _, err := m.system.RunWithRetries(cmd, 30*time.Second); err != nil {
+        slog.Warn("microceph: ceph status check failed", "error", err)
+    }
+
+    // Enable RADOS Gateway on alternate ports to avoid collisions with traefik
+    cmd = system.NewCommand("microceph", []string{"enable", "rgw", "--port", "8080", "--ssl-port", "8443"})
+    if _, err := m.system.RunWithRetries(cmd, 2*time.Minute); err != nil {
+        return fmt.Errorf("failed to enable radosgw: %w", err)
+    }
+
+    // Ensure ceph is up after enabling rgw
+    cmd = system.NewCommand("microceph.ceph", []string{"-s"})
+    if _, err := m.system.RunWithRetries(cmd, 30*time.Second); err != nil {
+        slog.Warn("microceph: post-enable ceph status check failed", "error", err)
+    }
+
+    // Create a default S3 user
+    cmd = system.NewCommand("microceph.radosgw-admin", []string{"user", "create", "--uid=user", "--display-name=User"})
+    if _, err := m.system.RunWithRetries(cmd, 30*time.Second); err != nil {
+        // It may already exist; log and continue
+        slog.Warn("microceph: failed to create radosgw user", "error", err)
+    }
+
+    // Create keys for the user. Use fixed keys to allow tests/users to connect easily.
+    cmd = system.NewCommand("microceph.radosgw-admin", []string{"key", "create", "--uid=user", "--key-type=s3", "--access-key=access-key", "--secret-key=secret-key"})
+    if _, err := m.system.RunWithRetries(cmd, 30*time.Second); err != nil {
+        slog.Warn("microceph: failed to create radosgw keys", "error", err)
+    }
+
+    // Install s3cmd using apt (best-effort)
+    cmd = system.NewCommand("apt", []string{"update"})
+    if _, err := m.system.Run(cmd); err != nil {
+        slog.Warn("microceph: apt update failed", "error", err)
+    }
+    cmd = system.NewCommand("apt", []string{"install", "-y", "s3cmd"})
+    if _, err := m.system.Run(cmd); err != nil {
+        slog.Warn("microceph: failed to install s3cmd", "error", err)
+    }
+
+    slog.Info("Prepared provider", "provider", m.Name())
+    return nil
+}
+
+func (m *MicroCeph) Name() string { return "microceph" }
+
+func (m *MicroCeph) Bootstrap() bool { return false }
+
+func (m *MicroCeph) CloudName() string { return "microceph" }
+
+func (m *MicroCeph) GroupName() string { return "microceph" }
+
+func (m *MicroCeph) Credentials() map[string]interface{} { return nil }
+
+func (m *MicroCeph) ModelDefaults() map[string]string { return nil }
+
+func (m *MicroCeph) BootstrapConstraints() map[string]string { return nil }
+
+// Restore uninstalls microceph snap and removes s3cmd package.
+func (m *MicroCeph) Restore() error {
+    snapHandler := packages.NewSnapHandler(m.system, m.snaps)
+    if err := snapHandler.Restore(); err != nil {
+        return err
+    }
+
+    // Attempt to remove s3cmd
+    cmd := system.NewCommand("apt", []string{"remove", "-y", "s3cmd"})
+    if _, err := m.system.Run(cmd); err != nil {
+        slog.Warn("microceph: failed to remove s3cmd", "error", err)
+    }
+
+    slog.Info("Removed provider", "provider", m.Name())
+    return nil
+}

--- a/internal/providers/microceph_test.go
+++ b/internal/providers/microceph_test.go
@@ -1,0 +1,100 @@
+package providers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/canonical/concierge/internal/config"
+	"github.com/canonical/concierge/internal/system"
+)
+
+func TestNewMicroCeph(t *testing.T) {
+	type test struct {
+		config   *config.Config
+		expected *MicroCeph
+	}
+
+	noOverrides := &config.Config{}
+
+	channelInConfig := &config.Config{}
+	channelInConfig.Providers.MicroCeph.Channel = "latest/candidate"
+
+	overrides := &config.Config{}
+	overrides.Overrides.MicroCephChannel = "latest/edge"
+
+	system := system.NewMockSystem()
+
+	tests := []test{
+		{
+			config:   noOverrides,
+			expected: &MicroCeph{Channel: defaultMicroCephChannel, system: system},
+		},
+		{
+			config:   channelInConfig,
+			expected: &MicroCeph{Channel: "latest/candidate", system: system},
+		},
+		{
+			config:   overrides,
+			expected: &MicroCeph{Channel: "latest/edge", system: system},
+		},
+	}
+
+	for _, tc := range tests {
+		mceph := NewMicroCeph(system, tc.config)
+
+		// Check the constructed snaps are correct
+		if mceph.snaps[0].Channel != tc.expected.Channel {
+			t.Fatalf("expected: %v, got: %v", mceph.snaps[0].Channel, tc.expected.Channel)
+		}
+
+		// Remove the snaps so the rest of the object can be compared
+		mceph.snaps = nil
+		if !reflect.DeepEqual(tc.expected, mceph) {
+			t.Fatalf("expected: %v, got: %v", tc.expected, mceph)
+		}
+	}
+}
+
+func TestMicroCephPrepareCommands(t *testing.T) {
+	config := &config.Config{}
+	config.Providers.MicroCeph.Channel = "latest/stable"
+
+	expectedCommands := []string{
+		"snap install microceph --channel latest/stable",
+		"microceph cluster bootstrap",
+		"microceph disk add loop,4G,3",
+		"microceph.ceph -s",
+		"microceph enable rgw --port 8080 --ssl-port 8443",
+		"microceph.ceph -s",
+		"microceph.radosgw-admin user create --uid=user --display-name=User",
+		"microceph.radosgw-admin key create --uid=user --key-type=s3 --access-key=access-key --secret-key=secret-key",
+		"apt update",
+		"apt install -y s3cmd",
+	}
+
+	system := system.NewMockSystem()
+	mceph := NewMicroCeph(system, config)
+	mceph.Prepare()
+
+	if !reflect.DeepEqual(expectedCommands, system.ExecutedCommands) {
+		t.Fatalf("expected commands:\n%v\ngot:\n%v", expectedCommands, system.ExecutedCommands)
+	}
+}
+
+func TestMicroCephRestore(t *testing.T) {
+	config := &config.Config{}
+	config.Providers.MicroCeph.Channel = "latest/stable"
+
+	system := system.NewMockSystem()
+	mceph := NewMicroCeph(system, config)
+	mceph.Restore()
+
+	expectedCommands := []string{
+		"snap remove microceph --purge",
+		"apt remove -y s3cmd",
+	}
+
+	if !reflect.DeepEqual(expectedCommands, system.ExecutedCommands) {
+		t.Fatalf("expected commands:\n%v\ngot:\n%v", expectedCommands, system.ExecutedCommands)
+	}
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -11,6 +11,7 @@ var SupportedProviders []string = []string{
 	"google",
 	"lxd",
 	"microk8s",
+	"microceph",
 }
 
 // Provider describes the set of methods expected to be available on a
@@ -45,6 +46,8 @@ func NewProvider(providerName string, system system.Worker, config *config.Confi
 		return NewMicroK8s(system, config)
 	} else if providerName == "google" && config.Providers.Google.Enable {
 		return NewGoogle(system, config)
+	} else if providerName == "microceph" && config.Providers.MicroCeph.Enable {
+		return NewMicroCeph(system, config)
 	} else if providerName == "k8s" && config.Providers.K8s.Enable {
 		return NewK8s(system, config)
 	} else {


### PR DESCRIPTION
NOTE: This PR was created entirely by copilot + Sonnet 3.5 and has not yet been reviewed manually.

Fixes #60.

---

Adds support for installing and configuring MicroCeph to provide S3-compatible object storage via RADOS Gateway. This is useful for testing and development of charms that require S3 access, such as COS charms.

Features:
- New `microceph` provider with snap installation and configuration
- MicroCeph RADOS Gateway enabled on ports 8080/8443 (avoiding Traefik conflicts)
- Default S3 user created with fixed credentials for easy testing
- s3cmd package installed for bucket management
- New `storage` preset combining LXD and MicroCeph
- Channel override support via `--microceph-channel` flag or `CONCIERGE_MICROCEPH_CHANNEL` env var

Example usage:
```bash
# Install using storage preset
sudo concierge prepare -p storage

# Create test bucket
s3cmd --host=localhost:8080 --access_key=access-key --secret_key=secret-key --host-bucket= --no-ssl mb s3://mybucket
```