### PR TITLE
fix: don't retry permanent errors in RunWithRetries

### DIFF
--- a/internal/system/helpers.go
+++ b/internal/system/helpers.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -36,6 +37,8 @@ func RunExclusive(w Worker, c *Command) ([]byte, error) {
 
 // RunWithRetries retries the command using exponential backoff, starting at
 // 1 second. Retries will be attempted up to the specified maximum duration.
+// Errors that are known to be permanent (e.g. ErrNotInstalled) are returned
+// immediately without retrying.
 func RunWithRetries(w Worker, c *Command, maxDuration time.Duration) ([]byte, error) {
 	backoff := retry.NewExponential(1 * time.Second)
 	backoff = retry.WithMaxDuration(maxDuration, backoff)
@@ -44,6 +47,9 @@ func RunWithRetries(w Worker, c *Command, maxDuration time.Duration) ([]byte, er
 	return retry.DoValue(ctx, backoff, func(ctx context.Context) ([]byte, error) {
 		output, err := w.Run(c)
 		if err != nil {
+			if errors.Is(err, ErrNotInstalled) {
+				return nil, err
+			}
 			return nil, retry.RetryableError(err)
 		}
 


### PR DESCRIPTION
## Summary

`RunWithRetries` in `internal/system/helpers.go` previously wrapped **all** errors with `retry.RetryableError`, meaning permanent failures such as `ErrNotInstalled` (binary not found) were retried with exponential backoff for the full `maxDuration` — typically 5 minutes — before finally being reported.

This change:

- **Treats `ErrNotInstalled` as a permanent error**, returning it immediately without retrying. This sentinel error is returned by `DryRunWorker` when a read-only command's binary is not on the system, and retrying it cannot succeed.

## Motivation

Several call sites pass a 5-minute `maxDuration`. When a command fails with a permanent error (e.g. a snap or binary that simply does not exist), the user experiences an unexplained 5-minute hang before the error is finally surfaced. This is particularly problematic in dry-run mode where `ErrNotInstalled` is the expected signal that a binary is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code) but owned by me.