### PR TITLE
fix: use MicroK8s config for model defaults and bootstrap constraints

### DIFF
--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -33,8 +33,8 @@ func NewMicroK8s(r system.Worker, config *config.Config) *MicroK8s {
 		Addons:               config.Providers.MicroK8s.Addons,
 		ImageRegistry:        config.Providers.MicroK8s.ImageRegistry,
 		bootstrap:            config.Providers.MicroK8s.Bootstrap,
-		modelDefaults:        config.Providers.Google.ModelDefaults,
-		bootstrapConstraints: config.Providers.Google.BootstrapConstraints,
+		modelDefaults:        config.Providers.MicroK8s.ModelDefaults,
+		bootstrapConstraints: config.Providers.MicroK8s.BootstrapConstraints,
 		system:               r,
 		snaps: []*system.Snap{
 			{Name: "microk8s", Channel: channel},


### PR DESCRIPTION
## Summary

- Fix copy-paste bug in `NewMicroK8s` constructor where `modelDefaults` and `bootstrapConstraints` were incorrectly read from `config.Providers.Google` instead of `config.Providers.MicroK8s`
- This meant MicroK8s providers would silently receive Google's model defaults and bootstrap constraints, leading to incorrect configuration
- The correct pattern is already used in `NewK8s` (`k8s.go`) and `NewLXD` (`lxd.go`), which each reference their own provider configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code) but owned by me.