### PR TITLE
chore: update Go version to 1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/concierge
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b


### PR DESCRIPTION
Pulls in security fixes and avoids the static checks failing.

(I missed that there was a .3 when I recently did the .2 release :disappointed:).