### PR TITLE
feat: add astral-uv to the dev preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ understanding what a particular preset or configuration file includes.
 
 `concierge` comes with a number of presets that are likely to serve most charm development needs:
 
-| Preset Name | Included                                                                  |
-| :---------: | :------------------------------------------------------------------------ |
-|  `crafts`   | `lxd`, `snapcraft`, `charmcraft`, `rockcraft`                             |
+| Preset Name | Included                                                                           |
+| :---------: | :--------------------------------------------------------------------------------- |
+|  `crafts`   | `lxd`, `snapcraft`, `charmcraft`, `rockcraft`                                      |
 |    `dev`    | `juju`, `k8s`, `lxd`, `snapcraft`, `charmcraft`, `rockcraft`, `jhack`, `astral-uv` |
-|    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
-| `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |
-|  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                  |
+|    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                                    |
+| `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                               |
+|  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                           |
 
 Note that in the `microk8s`/`k8s` presets, while `lxd` is installed, it is not bootstrapped. It is
 installed and initialised with enough config such that `charmcraft` can use it as a build backend.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ understanding what a particular preset or configuration file includes.
 | Preset Name | Included                                                                  |
 | :---------: | :------------------------------------------------------------------------ |
 |  `crafts`   | `lxd`, `snapcraft`, `charmcraft`, `rockcraft`                             |
-|    `dev`    | `juju`, `k8s`, `lxd`, `snapcraft`, `charmcraft`, `rockcraft`, `jhack`     |
+|    `dev`    | `juju`, `k8s`, `lxd`, `snapcraft`, `charmcraft`, `rockcraft`, `jhack`, `astral-uv` |
 |    `k8s`    | `juju`, `k8s`, `lxd`, `rockcraft`, `charmcraft`                           |
 | `microk8s`  | `juju`, `microk8s`, `lxd`, `rockcraft`, `charmcraft`                      |
 |  `machine`  | `juju`, `lxd`, `snapcraft`, `charmcraft`                                  |

--- a/presets/dev.yaml
+++ b/presets/dev.yaml
@@ -25,6 +25,7 @@ host:
     - python3-pip
     - python3-venv
   snaps:
+    astral-uv:
     charmcraft:
     jq:
     yq:

--- a/tests/preset-dev/task.yaml
+++ b/tests/preset-dev/task.yaml
@@ -8,7 +8,7 @@ execute: |
   "$SPREAD_PATH"/concierge --trace prepare -p dev
 
   # Check that relevant snaps are installed
-  for s in juju k8s lxd kubectl jq yq charmcraft rockcraft snapcraft; do
+  for s in juju k8s lxd kubectl jq yq charmcraft rockcraft snapcraft astral-uv; do
     snap list "$s" | MATCH $s
   done
 


### PR DESCRIPTION
Adds the `astral-uv` snap to the Concierge built-in `dev` preset, since so many charmers use `uv`.

Fixes #194