### PR TITLE
ci: drop colliding concurrency group from sbom-secscan workflow

### DIFF
--- a/.github/workflows/sbom-secscan.yaml
+++ b/.github/workflows/sbom-secscan.yaml
@@ -6,9 +6,11 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+# No `concurrency` here on purpose: in a called reusable workflow
+# `github.workflow` resolves to the caller's name, so a
+# `${{ github.workflow }}-${{ github.ref }}` group collides with the caller's
+# own group. With cancel-in-progress that cancels the caller's job. The caller
+# (release.yaml) already manages concurrency.
 
 jobs:
   scan:


### PR DESCRIPTION
In a called reusable workflow, github.workflow resolves to the caller's name, so sbom-secscan's `${{ github.workflow }}-${{ github.ref }}` concurrency group collided with release.yaml's identical group. With cancel-in-progress: true, starting the called workflow cancelled the caller's job, failing the release (v1.6.0). Let the caller own concurrency.