### PR TITLE
ci: build for all linux/* architectures supported by Go

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,11 @@ builds:
       - arm64
       - ppc64le
       - s390x
+      - "386"
+      - arm
+      - riscv64
+    goarm:
+      - "7"
     ldflags:
       - -X github.com/canonical/concierge/cmd.version={{ .Version }} -X github.com/canonical/concierge/cmd.commit={{ .Commit }}
 


### PR DESCRIPTION
Add 386 (i386), arm (armhf, GOARM=7), and riscv64 to the build matrix so release artifacts cover every linux/* target Go supports cleanly.

Cross-compile verified locally with CGO_ENABLED=0 on Go 1.26 — all three new triples build from the current sources without changes.

These are probably not that useful for Concierge users, but will become required at some point in the future.