### PR TITLE
ci: don't attempt to comment on the PR from the dependency-action workflow

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
@@ -22,4 +21,3 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
-          comment-summary-in-pr: on-failure


### PR DESCRIPTION
Drop comment-summary-in-pr: on-failure and the pull-requests: write permission from the dependency-review workflow. The default GITHUB_TOKEN on fork PRs is read-only, so the comment post fails. The job still fails on high-severity findings; the summary lands in the Actions log.