### PR TITLE
ci: build for all linux/* architectures supported by Go (backport #200 to 1.5)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,11 @@ builds:
       - arm64
       - ppc64le
       - s390x
+      - "386"
+      - arm
+      - riscv64
+    goarm:
+      - "7"
     ldflags:
       - -X github.com/canonical/concierge/cmd.version={{ .Version }} -X github.com/canonical/concierge/cmd.commit={{ .Commit }}
 


### PR DESCRIPTION
Backport of #200 to the 1.5-maintenance line. Adds 386 (i386), arm (armhf, GOARM=7) and riscv64 to the goreleaser build matrix so 1.5 release artifacts cover every linux/* target Go supports cleanly.

Clean cherry-pick of 3ef5241. Cross-compile verified locally with CGO_ENABLED=0 on Go 1.26.