### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/concierge
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/canonical/x-go v0.0.0-20230522092633-7947a7587f5b


### PR DESCRIPTION
Update go.mod's go directive from 1.26.1 to the latest stable Go release on the 1.5-maintenance line. Equivalent to applying #191, #193 and #204 in a single step (they're each one-line bumps along the 1.26 patch series).

Build and tests pass locally on Go 1.26.4.