### PR TITLE
fix: wait for MicroK8s to settle before configuring image registry

### DIFF
--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -66,15 +66,17 @@ func (m *MicroK8s) Prepare() error {
 		return fmt.Errorf("failed to install MicroK8s: %w", err)
 	}
 
-	// Configure image registry before waiting for MicroK8s to be ready
-	err = m.configureImageRegistry()
-	if err != nil {
-		return fmt.Errorf("failed to configure image registry: %w", err)
-	}
-
+	// Wait for MicroK8s to be ready before configuring the image registry:
+	// `microk8s stop` fails with "service-control change in progress" if
+	// snapd is still bringing the snap's services up after install.
 	err = m.init()
 	if err != nil {
 		return fmt.Errorf("failed to initialize MicroK8s: %w", err)
+	}
+
+	err = m.configureImageRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to configure image registry: %w", err)
 	}
 
 	err = m.enableAddons()
@@ -193,7 +195,9 @@ func (m *MicroK8s) configureImageRegistry() error {
 		return fmt.Errorf("failed to start MicroK8s: %w", err)
 	}
 
-	return nil
+	// Wait for services to come back up before downstream steps run
+	// commands that assume a ready cluster.
+	return m.init()
 }
 
 // buildHostsToml generates the hosts.toml configuration for containerd using

--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -206,7 +206,10 @@ func (m *MicroK8s) buildHostsToml() string {
 	return buildHostsTomlFromConfig(m.ImageRegistry)
 }
 
-// init ensures that MicroK8s is installed, minimally configured, and ready.
+// init waits for MicroK8s to be ready (via `microk8s status --wait-ready`).
+// Named for parity with the other providers' init() methods, even though
+// MicroK8s has nothing to do here beyond waiting; callers may invoke it more
+// than once to re-synchronise after operations like stop/start.
 func (m *MicroK8s) init() error {
 	cmd := system.NewCommand("microk8s", []string{"status", "--wait-ready", "--timeout", "270"})
 	_, err := system.RunWithRetries(m.system, cmd, 5*time.Minute)

--- a/internal/providers/microk8s.go
+++ b/internal/providers/microk8s.go
@@ -71,7 +71,7 @@ func (m *MicroK8s) Prepare() error {
 	// snapd is still bringing the snap's services up after install.
 	err = m.init()
 	if err != nil {
-		return fmt.Errorf("failed to initialize MicroK8s: %w", err)
+		return fmt.Errorf("failed to configure MicroK8s: %w", err)
 	}
 
 	err = m.configureImageRegistry()

--- a/internal/providers/microk8s_test.go
+++ b/internal/providers/microk8s_test.go
@@ -176,6 +176,7 @@ func TestMicroK8sPrepareWithImageRegistry(t *testing.T) {
 	expectedCommands := []string{
 		"snap install microk8s --channel 1.31-strict/stable",
 		"snap install kubectl --channel stable",
+		"microk8s status --wait-ready --timeout 270",
 		"microk8s stop",
 		"microk8s start",
 		"microk8s status --wait-ready --timeout 270",


### PR DESCRIPTION
This PR avoids a race in the `microk8s` provider, when using the image registry config feature.

- Reorder `MicroK8s.Prepare()` so `microk8s status --wait-ready` runs *before* `configureImageRegistry`'s `stop`/`start`, and again after the `start`.
- Without the first wait, `microk8s stop` races with snapd's in-progress `service-control` change from the just-completed `snap install microk8s`, either failing outright (`snap "microk8s" has "service-control" change in progress`, as in #216) or completing nominally but leaving the cluster wedged so later wait-ready calls time out.
- Without the second wait, downstream commands like `microk8s config` (no retries) could fire before services come back up.

Reproduced on `main` in a fresh Multipass 24.04 VM with a `concierge.yaml` enabling MicroK8s + `image-registry.url`: `microk8s stop` fired 1.3s after `snap install microk8s` finished; `microk8s start` reported success but services stayed down; two consecutive `wait-ready` timeouts and concierge bailed. This isn't exactly the same as in the issue, but it's the same root cause: there's a race.

With the patch on the same VM (snaps purged, source replaced): clean run — `wait-ready` → `stop` → `start` → `wait-ready` → `microk8s config` → `Prepared provider`.

I checked the other providers (`k8s`, `lxd`, `juju`) and there's no equivalent race.

Fixes #216.