### PR TITLE
fix: lift juju bootstrap retry budget and bootstrap-timeout default

### DIFF
--- a/internal/juju/juju.go
+++ b/internal/juju/juju.go
@@ -246,7 +246,11 @@ func (j *JujuHandler) bootstrapProvider(provider providers.Provider) error {
 	user := j.system.User().Username
 
 	cmd := system.NewCommandAs(user, provider.GroupName(), "juju", bootstrapArgs)
-	_, err = system.RunWithRetries(j.system, cmd, 5*time.Minute)
+	// `juju bootstrap` can take 10+ minutes per attempt to fail on a slow
+	// runner (controller pod takes time to expose its API), so a 5-minute
+	// retry budget elapses inside the first attempt and we never retry.
+	// Use a 30-minute budget so a transient failure gets a real second go.
+	_, err = system.RunWithRetries(j.system, cmd, 30*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/internal/juju/juju_test.go
+++ b/internal/juju/juju_test.go
@@ -111,7 +111,7 @@ func TestJujuHandlerCommandsPresets(t *testing.T) {
 			expectedCommands: []string{
 				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-microk8s",
-				"sudo -u test-user -g snap_microk8s juju bootstrap microk8s concierge-microk8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true",
+				"sudo -u test-user -g snap_microk8s juju bootstrap microk8s concierge-microk8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true --config bootstrap-timeout=1800",
 				"sudo -u test-user juju add-model -c concierge-microk8s testing",
 				fmt.Sprintf("sudo -u test-user juju set-model-constraints -m concierge-microk8s:testing arch=%s", goArchToJujuArch(runtime.GOARCH)),
 			},
@@ -122,7 +122,7 @@ func TestJujuHandlerCommandsPresets(t *testing.T) {
 			expectedCommands: []string{
 				"snap install juju",
 				"sudo -u test-user juju show-controller concierge-k8s",
-				"sudo -u test-user juju bootstrap k8s concierge-k8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints root-disk=2G",
+				"sudo -u test-user juju bootstrap k8s concierge-k8s --verbose --model-default automatically-retry-hooks=false --model-default test-mode=true --bootstrap-constraints root-disk=2G --config bootstrap-timeout=1800",
 				"sudo -u test-user juju add-model -c concierge-k8s testing",
 				fmt.Sprintf("sudo -u test-user juju set-model-constraints -m concierge-k8s:testing arch=%s", goArchToJujuArch(runtime.GOARCH)),
 			},

--- a/presets/k8s.yaml
+++ b/presets/k8s.yaml
@@ -1,4 +1,8 @@
 juju:
+  # The default 20-minute bootstrap timeout is too short for the controller
+  # pod to expose its API on slow CI runners; pin a longer one so the
+  # preset works out of the box on busy GHA hosts.
+  extra-bootstrap-args: --config bootstrap-timeout=1800
   model-defaults:
     test-mode: "true"
     automatically-retry-hooks: "false"

--- a/presets/microk8s.yaml
+++ b/presets/microk8s.yaml
@@ -1,4 +1,8 @@
 juju:
+  # The default 20-minute bootstrap timeout is too short for the controller
+  # pod to expose its API on slow CI runners; pin a longer one so the
+  # preset works out of the box on busy GHA hosts.
+  extra-bootstrap-args: --config bootstrap-timeout=1800
   model-defaults:
     test-mode: "true"
     automatically-retry-hooks: "false"


### PR DESCRIPTION
On slow CI runners `concierge prepare -p k8s` regularly fails on `unable to contact api server after 60 attempts` because the default 20-minute `juju bootstrap-timeout` is too short for the controller pod to expose its API. Two complementary fixes:

* Lift the `system.RunWithRetries` budget around `juju bootstrap` from 5 minutes to 30 minutes. A single failed bootstrap attempt currently takes 10+ minutes on a slow host, which is enough to exhaust the 5-minute retry budget inside the first attempt, so the retry machinery never gets a real go. 30 minutes gives a transient failure a real second attempt.
* Set `juju.extra-bootstrap-args: --config bootstrap-timeout=1800` in the `k8s` and `microk8s` presets so the default "works out of the box" on busy GHA hosts.
