### PR TITLE
ci: attest release artifacts via actions/attest-build-provenance

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -165,18 +165,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
 
-      # Attest the release tarballs via GitHub's attestations API +
-      # Sigstore transparency log, matching the fleet pattern used by
-      # canonical/pebble, canonical/operator, canonical/jubilant,
-      # canonical/pytest-jubilant, canonical/charmlibs, and
-      # canonical/charmhub-listing-review. Consumers verify with
+      # Attest the release tarballs via GitHub's attestations API and
+      # Sigstore transparency log. Consumers verify with
       # `gh attestation verify`.
       #
       # goreleaser v2 has a built-in `slsa:` block that emits a separate
       # `.intoto.jsonl` sidecar in a different format; it is not integrated
       # with GitHub's attestation API and would need its own verification
-      # story. Using actions/attest-build-provenance here keeps concierge
-      # consistent with the rest of the Charm Tech fleet.
+      # story.
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@v4.1.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,7 +129,7 @@ jobs:
     environment: main
     permissions:
       contents: write
-      # For actions/attest-build-provenance below.
+      # For actions/attest below.
       id-token: write
       attestations: write
     needs:
@@ -174,7 +174,7 @@ jobs:
       # with GitHub's attestation API and would need its own verification
       # story.
       - name: Attest release artifacts
-        uses: actions/attest-build-provenance@v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # 4.1.1
         with:
           subject-path: "dist/*.tar.gz"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -129,6 +129,9 @@ jobs:
     environment: main
     permissions:
       contents: write
+      # For actions/attest-build-provenance below.
+      id-token: write
+      attestations: write
     needs:
       - spread-test
     steps:
@@ -161,6 +164,23 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
+
+      # Attest the release tarballs via GitHub's attestations API +
+      # Sigstore transparency log, matching the fleet pattern used by
+      # canonical/pebble, canonical/operator, canonical/jubilant,
+      # canonical/pytest-jubilant, canonical/charmlibs, and
+      # canonical/charmhub-listing-review. Consumers verify with
+      # `gh attestation verify`.
+      #
+      # goreleaser v2 has a built-in `slsa:` block that emits a separate
+      # `.intoto.jsonl` sidecar in a different format; it is not integrated
+      # with GitHub's attestation API and would need its own verification
+      # story. Using actions/attest-build-provenance here keeps concierge
+      # consistent with the rest of the Charm Tech fleet.
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v4.1.0
+        with:
+          subject-path: "dist/*.tar.gz"
 
   sbom-secscan:
     name: SBOM and secscan


### PR DESCRIPTION
The Canonical Security "Repository security" reference recommends provenance attestations for release artifacts (SLSA / Sigstore / cosign). Every other Charm Tech-owned repo that ships release artifacts already does this via actions/attest-build-provenance; concierge was the only outlier.

Wiring:

- id-token: write + attestations: write on the release job so the action can call the attestations API and Sigstore.
- Attest step after `goreleaser release`, targeting dist/*.tar.gz (the per-arch tarballs goreleaser leaves in dist/). The snap is published straight to the Snap Store by goreleaser and doesn't need a separate attestation here.

Consumers verify with `gh attestation verify <tarball> --repo canonical/concierge`.

Not using goreleaser's built-in `slsa:` block: it writes a separate .intoto.jsonl sidecar in a different format and is not integrated with GitHub's attestations API, so it would need its own verification path. actions/attest keeps concierge consistent with pebble, operator, jubilant, pytest-jubilant, charmlibs, and charmhub-listing-review.