### PR TITLE
fix: run apt operations non-interactively so prepare cannot hang on prompts

### DIFF
--- a/internal/packages/deb_handler.go
+++ b/internal/packages/deb_handler.go
@@ -42,7 +42,7 @@ var aptEnv = []string{
 // aptCommand constructs an apt-get command that runs non-interactively so
 // package operations never hang waiting for user input.
 func aptCommand(args ...string) *system.Command {
-	cmd := system.NewCommand("apt-get", args)
+	cmd := system.NewCommand("apt-get", append([]string{"-y"}, args...))
 	cmd.Env = aptEnv
 	return cmd
 }
@@ -76,7 +76,7 @@ func (h *DebHandler) Restore() error {
 		}
 	}
 
-	cmd := aptCommand("autoremove", "-y")
+	cmd := aptCommand("autoremove")
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {
@@ -88,7 +88,7 @@ func (h *DebHandler) Restore() error {
 
 // installDeb uses `apt` to install the package on the system from the archives.
 func (h *DebHandler) installDeb(d *Deb) error {
-	cmd := aptCommand("install", "-y",
+	cmd := aptCommand("install",
 		"-o", "Dpkg::Options::=--force-confdef",
 		"-o", "Dpkg::Options::=--force-confold",
 		d.Name)
@@ -104,7 +104,7 @@ func (h *DebHandler) installDeb(d *Deb) error {
 
 // Remove uninstalls the deb from the system with `apt`.
 func (h *DebHandler) removeDeb(d *Deb) error {
-	cmd := aptCommand("remove", "-y", d.Name)
+	cmd := aptCommand("remove", d.Name)
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {

--- a/internal/packages/deb_handler.go
+++ b/internal/packages/deb_handler.go
@@ -31,6 +31,22 @@ type DebHandler struct {
 	system system.Worker
 }
 
+// aptEnv contains environment variables that prevent apt/dpkg (and tools
+// hooked into them, such as needrestart) from blocking on interactive
+// prompts during unattended package operations.
+var aptEnv = []string{
+	"DEBIAN_FRONTEND=noninteractive",
+	"NEEDRESTART_MODE=a",
+}
+
+// aptCommand constructs an apt-get command that runs non-interactively so
+// package operations never hang waiting for user input.
+func aptCommand(args ...string) *system.Command {
+	cmd := system.NewCommand("apt-get", args)
+	cmd.Env = aptEnv
+	return cmd
+}
+
 // Prepare updates the apt cache and installs a set of debs from the archive.
 func (h *DebHandler) Prepare() error {
 	if len(h.Debs) == 0 {
@@ -60,7 +76,7 @@ func (h *DebHandler) Restore() error {
 		}
 	}
 
-	cmd := system.NewCommand("apt-get", []string{"autoremove", "-y"})
+	cmd := aptCommand("autoremove", "-y")
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {
@@ -72,7 +88,10 @@ func (h *DebHandler) Restore() error {
 
 // installDeb uses `apt` to install the package on the system from the archives.
 func (h *DebHandler) installDeb(d *Deb) error {
-	cmd := system.NewCommand("apt-get", []string{"install", "-y", d.Name})
+	cmd := aptCommand("install", "-y",
+		"-o", "Dpkg::Options::=--force-confdef",
+		"-o", "Dpkg::Options::=--force-confold",
+		d.Name)
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {
@@ -85,7 +104,7 @@ func (h *DebHandler) installDeb(d *Deb) error {
 
 // Remove uninstalls the deb from the system with `apt`.
 func (h *DebHandler) removeDeb(d *Deb) error {
-	cmd := system.NewCommand("apt-get", []string{"remove", "-y", d.Name})
+	cmd := aptCommand("remove", "-y", d.Name)
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {
@@ -98,7 +117,7 @@ func (h *DebHandler) removeDeb(d *Deb) error {
 
 // updateAptCache is a helper method to update the host's package cache.
 func (h *DebHandler) updateAptCache() error {
-	cmd := system.NewCommand("apt-get", []string{"update"})
+	cmd := aptCommand("update")
 
 	_, err := system.RunExclusive(h.system, cmd)
 	if err != nil {

--- a/internal/packages/deb_handler_test.go
+++ b/internal/packages/deb_handler_test.go
@@ -17,17 +17,17 @@ func TestDebHandlerCommands(t *testing.T) {
 		{
 			func(d *DebHandler) { _ = d.Prepare() },
 			[]string{
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update",
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold cowsay",
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold python3-venv",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y update",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y install -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold cowsay",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y install -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold python3-venv",
 			},
 		},
 		{
 			func(d *DebHandler) { _ = d.Restore() },
 			[]string{
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get remove -y cowsay",
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get remove -y python3-venv",
-				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get autoremove -y",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y remove cowsay",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y remove python3-venv",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y autoremove",
 			},
 		},
 	}

--- a/internal/packages/deb_handler_test.go
+++ b/internal/packages/deb_handler_test.go
@@ -17,17 +17,17 @@ func TestDebHandlerCommands(t *testing.T) {
 		{
 			func(d *DebHandler) { _ = d.Prepare() },
 			[]string{
-				"apt-get update",
-				"apt-get install -y cowsay",
-				"apt-get install -y python3-venv",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold cowsay",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold python3-venv",
 			},
 		},
 		{
 			func(d *DebHandler) { _ = d.Restore() },
 			[]string{
-				"apt-get remove -y cowsay",
-				"apt-get remove -y python3-venv",
-				"apt-get autoremove -y",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get remove -y cowsay",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get remove -y python3-venv",
+				"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get autoremove -y",
 			},
 		},
 	}

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -78,8 +78,8 @@ func TestK8sPrepareCommands(t *testing.T) {
 
 	expectedCommands := []string{
 		"which iptables",
-		"apt-get update",
-		"apt-get install -y iptables",
+		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update",
+		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold iptables",
 		fmt.Sprintf("snap install k8s --channel %s", defaultK8sChannel),
 		"snap install kubectl --channel stable",
 		"systemctl is-active containerd.service",

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -78,8 +78,8 @@ func TestK8sPrepareCommands(t *testing.T) {
 
 	expectedCommands := []string{
 		"which iptables",
-		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update",
-		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold iptables",
+		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y update",
+		"DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y install -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold iptables",
 		fmt.Sprintf("snap install k8s --channel %s", defaultK8sChannel),
 		"snap install kubectl --channel stable",
 		"systemctl is-active containerd.service",

--- a/internal/system/command.go
+++ b/internal/system/command.go
@@ -25,6 +25,11 @@ type Command struct {
 	// where certain errors are an expected part of normal operation (e.g., checking
 	// if a controller exists before bootstrapping).
 	ExpectedError string
+	// Env contains extra environment variables, in "KEY=value" form, that are set
+	// for the command. These are rendered as assignments immediately preceding the
+	// executable, which works both for plain shell invocations and for commands
+	// run via `sudo`.
+	Env []string
 }
 
 // NewCommand constructs a command to be run as the current user/group.
@@ -88,6 +93,7 @@ func (c *Command) CommandString() string {
 		cmdArgs = append(cmdArgs, "-g", c.Group)
 	}
 
+	cmdArgs = append(cmdArgs, c.Env...)
 	cmdArgs = append(cmdArgs, c.Executable)
 	cmdArgs = append(cmdArgs, c.Args...)
 

--- a/internal/system/command_test.go
+++ b/internal/system/command_test.go
@@ -130,6 +130,25 @@ func TestCommandString(t *testing.T) {
 			command:  NewCommandAs("test-user", "apters", "CONCIERGE_TEST_COMMAND", []string{"install", "-y", "cowsay"}),
 			expected: "sudo -u test-user -g apters CONCIERGE_TEST_COMMAND install -y cowsay",
 		},
+		{
+			command: &Command{
+				Executable: "CONCIERGE_TEST_COMMAND",
+				Args:       []string{"install", "-y", "cowsay"},
+				Env:        []string{"DEBIAN_FRONTEND=noninteractive", "NEEDRESTART_MODE=a"},
+			},
+			// The env assignments must remain unquoted; a quoted word containing
+			// '=' is treated by the shell as a command name, not an assignment.
+			expected: "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a CONCIERGE_TEST_COMMAND install -y cowsay",
+		},
+		{
+			command: &Command{
+				Executable: "CONCIERGE_TEST_COMMAND",
+				Args:       []string{"install", "-y", "cowsay"},
+				User:       "test-user",
+				Env:        []string{"DEBIAN_FRONTEND=noninteractive"},
+			},
+			expected: "sudo -u test-user DEBIAN_FRONTEND=noninteractive CONCIERGE_TEST_COMMAND install -y cowsay",
+		},
 	}
 
 	for _, tc := range tests {

--- a/tests/extra-debs-noninteractive/task.yaml
+++ b/tests/extra-debs-noninteractive/task.yaml
@@ -23,8 +23,8 @@ execute: |
   dpkg -s gnome-keyring | MATCH "Status: install ok installed"
 
   # Check every apt command ran with a non-interactive frontend
-  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update" < prepare.log
-  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install" < prepare.log
+  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y update" < prepare.log
+  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get -y install" < prepare.log
 
 restore: |
   if [[ -z "${CI:-}" ]]; then

--- a/tests/extra-debs-noninteractive/task.yaml
+++ b/tests/extra-debs-noninteractive/task.yaml
@@ -1,0 +1,32 @@
+summary: Ensure apt operations run non-interactively and never block on prompts
+systems:
+  - ubuntu-24.04
+
+execute: |
+  pushd "${SPREAD_PATH}/${SPREAD_TASK}"
+
+  # Create an empty config file
+  touch concierge.yaml
+
+  # Make sure needrestart is installed: its apt hook raises an interactive
+  # "which services should be restarted?" prompt after package installs,
+  # which previously caused `concierge prepare` to hang (e.g. when
+  # installing gnome-keyring).
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq needrestart
+
+  # If apt were to prompt, prepare would block indefinitely; time out well
+  # before spread's kill-timeout so a regression fails quickly.
+  timeout 600 "$SPREAD_PATH"/concierge --trace prepare --extra-debs "gnome-keyring" > prepare.log 2>&1
+  cat prepare.log
+
+  # Check the deb was installed
+  dpkg -s gnome-keyring | MATCH "Status: install ok installed"
+
+  # Check every apt command ran with a non-interactive frontend
+  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get update" < prepare.log
+  MATCH "DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=a apt-get install" < prepare.log
+
+restore: |
+  if [[ -z "${CI:-}" ]]; then
+    "$SPREAD_PATH"/concierge --trace restore
+  fi


### PR DESCRIPTION
## Problem

`concierge prepare` can hang forever while installing debs. Deb packages were installed with a plain `apt-get install -y`, which still allows interactive prompts to block waiting for input:

- **needrestart**'s post-invoke *"which services should be restarted?"* dialog (installed by default on Ubuntu Server 22.04+) — this is the most common trigger, observed hanging a real `prepare -p dev` run on `apt-get install -y gnome-keyring` with the process tree stuck in `/usr/lib/needrestart/apt-pinvoke`
- debconf questions
- dpkg conffile conflict prompts

## Fix

- Add an `Env` field to `system.Command`, rendered as unquoted `KEY=value` assignments immediately before the executable. This form works both as a plain shell assignment and after a `sudo -u user` prefix (sudo accepts leading `VAR=value` args), and flows through the real runner, dry-run, and trace output unchanged.
- Run every `apt-get` command with `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a`.
- Pass `-o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold` on installs so conffile conflicts never prompt either.

## Testing

- Unit tests for `Env` rendering in `CommandString` (including the sudo case, and a guard that assignments stay unquoted — a quoted word containing `=` would be parsed by the shell as a command name, not an assignment); updated expected command strings in the deb handler and k8s provider tests.
- New spread test `tests/extra-debs-noninteractive`: ensures needrestart is installed, runs `prepare --extra-debs gnome-keyring` under a 600s timeout (so a regression fails fast rather than hitting the 90m kill-timeout), and asserts the non-interactive environment appears in the trace output.
- Verified end-to-end on the machine that exhibited the hang: the patched binary installs gnome-keyring in seconds with exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)