### PR TITLE
fix: K8s restore leaves image-registry credentials on disk

### DIFF
--- a/internal/providers/k8s.go
+++ b/internal/providers/k8s.go
@@ -133,11 +133,31 @@ func (k *K8s) Restore() error {
 		return fmt.Errorf("failed to remove '.kube' from user's home directory: %w", err)
 	}
 
+	k.restoreImageRegistry()
+
 	k.restoreContainerd()
 
 	slog.Info("Removed provider", "provider", k.Name())
 
 	return nil
+}
+
+// restoreImageRegistry removes the containerd hosts.d configuration that
+// configureImageRegistry wrote. The k8s snap uses host paths under
+// /etc/containerd/hosts.d/ that are not cleared when the snap is removed, so
+// credentials embedded in hosts.toml would otherwise persist on disk after
+// `concierge restore`. Failures are logged as warnings — restore has already
+// done the heavy lifting and we should not fail it over a stray file.
+func (k *K8s) restoreImageRegistry() {
+	if k.ImageRegistry.URL == "" {
+		return
+	}
+
+	hostsDir := "/etc/containerd/hosts.d/docker.io"
+	slog.Debug("Removing image registry configuration", "path", hostsDir)
+	if err := k.system.RemovePath(hostsDir); err != nil {
+		slog.Warn("Failed to remove image registry configuration", "path", hostsDir, "error", err)
+	}
 }
 
 // install ensures that K8s is installed.

--- a/internal/providers/k8s_test.go
+++ b/internal/providers/k8s_test.go
@@ -314,6 +314,55 @@ func TestK8sPrepareWithImageRegistry(t *testing.T) {
 	}
 }
 
+func TestK8sRestoreWithImageRegistry(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Providers.K8s.Channel = ""
+	cfg.Providers.K8s.Features = defaultFeatureConfig
+	cfg.Providers.K8s.ImageRegistry.URL = "https://mirror.example.com"
+	cfg.Providers.K8s.ImageRegistry.Username = "user"
+	cfg.Providers.K8s.ImageRegistry.Password = "pass"
+
+	sys := system.NewMockSystem()
+	// Mock that containerd service does not exist (typical case after k8s-only install)
+	sys.MockCommandReturn("systemctl list-unit-files containerd.service", []byte("0 unit files listed."), nil)
+
+	ck8s := NewK8s(sys, cfg)
+	if err := ck8s.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	expectedRemovedPaths := []string{
+		path.Join(os.TempDir(), ".kube"),
+		"/etc/containerd/hosts.d/docker.io",
+	}
+
+	if !slices.Equal(expectedRemovedPaths, sys.RemovedPaths) {
+		t.Fatalf("expected: %v, got: %v", expectedRemovedPaths, sys.RemovedPaths)
+	}
+}
+
+func TestK8sRestoreWithoutImageRegistryLeavesHostsDirAlone(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Providers.K8s.Channel = ""
+	cfg.Providers.K8s.Features = defaultFeatureConfig
+	// No ImageRegistry.URL set — configureImageRegistry never ran, so
+	// Restore must not touch /etc/containerd/hosts.d/*.
+
+	sys := system.NewMockSystem()
+	sys.MockCommandReturn("systemctl list-unit-files containerd.service", []byte("0 unit files listed."), nil)
+
+	ck8s := NewK8s(sys, cfg)
+	if err := ck8s.Restore(); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, p := range sys.RemovedPaths {
+		if strings.Contains(p, "/etc/containerd/hosts.d") {
+			t.Fatalf("expected /etc/containerd/hosts.d to be untouched, but %q was removed", p)
+		}
+	}
+}
+
 func TestK8sBuildHostsToml(t *testing.T) {
 	cfg := &config.Config{}
 	cfg.Providers.K8s.Channel = defaultK8sChannel


### PR DESCRIPTION
This PR changes restore to remove `/etc/containerd/hosts.d/docker.io` written by K8s.configureImageRegistry. The k8s snap uses host paths outside snap ownership, so credentials embedded in hosts.toml persist after the snap is uninstalled. Cleanup is skipped when image_registry was not configured, and failures are logged as warnings so restore is not failed over a stray file.

There is a chance that the user edited this file or for other reasons wants it. Concierge's restore is already aggressive in this way (removing packages, for example), so this is more in the same line. The user provided the credentials so would presumably still have them somewhere. In general, doing a restore should be avoided unless concierge did all the preparing.

Fixes #220